### PR TITLE
Invoke enhancements

### DIFF
--- a/provider/azureProvider.js
+++ b/provider/azureProvider.js
@@ -429,20 +429,28 @@ return new BbPromise((resolve, reject) => {
     if (eventType === 'http') {
       let queryString = '';
 
-      if (eventData) {
-        Object.keys(eventData).forEach((key) => {
-          const value = eventData[key];
+      if (eventData) {     
+        if (typeof eventData === "string") {
+          try {
+            eventData = JSON.parse(eventData);
+          }
+          catch (error) {
+            return BbPromise.reject("The specified input data isn't a valid JSON string. " +
+                                    "Please correct it and try invoking the function again.");
+          }
+        }
 
-          queryString = `${key}=${value}`;
-        });
+        queryString = Object.keys(eventData)
+                            .map((key) => `${key}=${eventData[key]}`)
+                            .join("&");
       }
+
       options = {
         'host': functionAppName + constants.functionAppDomain,
-        'port': 443,
         'path': `${constants.functionAppApiPath + functionName}?${queryString}`
       };
 
-return new BbPromise((resolve, reject) => {
+      return new BbPromise((resolve, reject) => {
         https.get(options, (res) => {
           let body = '';
 
@@ -459,30 +467,30 @@ return new BbPromise((resolve, reject) => {
         });
       });
     }
-      const requestUrl = `https://${functionAppName}${constants.functionsAdminApiPath}${functionName}`;
+    
+    const requestUrl = `https://${functionAppName}${constants.functionsAdminApiPath}${functionName}`;
       
-      options = {
-        'host': constants.functionAppDomain,
-        'method': 'post',
-        'body': eventData,
-        'url': requestUrl,
-        'json': true,
-        'headers': {
-          'x-functions-key': functionsAdminKey,
-          'Accept': 'application/json,*/*'
+    options = {
+      'host': constants.functionAppDomain,
+      'method': 'post',
+      'body': eventData,
+      'url': requestUrl,
+      'json': true,
+      'headers': {
+        'x-functions-key': functionsAdminKey,
+        'Accept': 'application/json,*/*'
+      }
+    };
+
+    return new BbPromise((resolve, reject) => {
+      request(options, (err, res, body) => {
+        if (err) {
+          reject(err);
         }
-      };
-
-return new BbPromise((resolve, reject) => {
-        request(options, (err, res, body) => {
-          if (err) {
-            reject(err);
-          }
-          this.serverless.cli.log(`Invoked function at: ${requestUrl}. \nResponse statuscode: ${res.statusCode}`);
-          resolve(res);
-        });
+        this.serverless.cli.log(`Invoked function at: ${requestUrl}. \nResponse statuscode: ${res.statusCode}`);
+        resolve(res);
       });
-
+    });
   }
 
   syncTriggers () {


### PR DESCRIPTION
This PR addresses two limitations with the way the `invoke` command currently handles function parameters:

1. It adds support for specifying the JSON config as a string literal (via the `-d` flag), in addition to the file-based support (via the `-p` flag).   

   ```shell
    serverless invoke -f hello -d '{"name":"JC"}'
   ```

2. It adds support for specifying multiple parameters (properties) in the provided JSON config (inline or file). Otherwise, `invoke` would only send the last parameter to the function invocation.

Some of the churn in the PR is related to formatting, which I did to improve the code folding support in VS Code (or other editors that rely on indentation).