### PR TITLE
Invoke enhancements

### DIFF
--- a/provider/azureProvider.js
+++ b/provider/azureProvider.js
@@ -8,7 +8,7 @@ const path = require('path');
 const fs = require('fs');
 const fse = require('fs-extra');
 const https = require('https');
-const JSZip = require('jszip');
+const zipFolder = require('zip-folder');
 const request = require('request');
 const dns = require('dns');
 const parseBindings = require('../shared/parseBindings');
@@ -59,7 +59,7 @@ const azureCredentials = {
 
 class AzureProvider {
   static getProviderName () {
-    return constants.providerName;
+return constants.providerName;
   }
 
   constructor (serverless) {
@@ -85,19 +85,19 @@ class AzureProvider {
 return this.parsedBindings;
   }
 
-  getSetting(key) {
+  getSetting (key) {
     // Loop through environment variables looking for the keys, case insentivie
     for (var k in process.env) {
       if (process.env.hasOwnProperty(k)) {
-        if(k.toLowerCase() === key.toLowerCase()) {
-          return process.env[k];
+        if (k.toLowerCase() === key.toLowerCase()) {
+      return process.env[k];
         }
       }
     }
   }
 
   LoginWithServicePrincipal () {
-    return new BbPromise((resolve, reject) => {
+return new BbPromise((resolve, reject) => {
       msRestAzure.loginWithServicePrincipalSecret(servicePrincipalClientId, servicePrincipalPassword, servicePrincipalTenantId, (error, credentials) => {
         if (error) {
           reject(error);
@@ -111,9 +111,9 @@ return this.parsedBindings;
 
   CreateResourceGroup () {
     const groupParameters = {
-'location': this.serverless.service.provider.location,
-'tags': {'sampletag': 'sampleValue'}
-};
+      'location': this.serverless.service.provider.location,
+      'tags': { 'sampletag': 'sampleValue' }
+    };
 
     this.serverless.cli.log(`Creating resource group: ${resourceGroupName}`);
     const resourceClient = new resourceManagement.ResourceManagementClient(principalCredentials, subscriptionId);
@@ -133,14 +133,14 @@ return new BbPromise((resolve, reject) => {
   CreateFunctionApp (method, params) {
     this.serverless.cli.log(`Creating function app: ${functionAppName}`);
     const resourceClient = new resourceManagement.ResourceManagementClient(principalCredentials, subscriptionId);
-    let parameters = {'functionAppName': {'value': functionAppName}};
+    let parameters = { 'functionAppName': { 'value': functionAppName } };
 
     const gitUrl = this.serverless.service.provider.gitUrl;
 
     if (gitUrl) {
       parameters = {
-        'functionAppName': {'value': functionAppName},
-        'gitUrl': {'value': gitUrl}
+        'functionAppName': { 'value': functionAppName },
+        'gitUrl': { 'value': gitUrl }
       };
     }
 
@@ -157,7 +157,7 @@ return new BbPromise((resolve, reject) => {
       for (let paramIndex = 0; paramIndex < userParametersKeys.length; paramIndex++) {
         const item = {};
 
-        item[userParametersKeys[paramIndex]] = {'value': userParameters[userParametersKeys[paramIndex]]};
+        item[userParametersKeys[paramIndex]] = { 'value': userParameters[userParametersKeys[paramIndex]] };
         parameters = _.merge(parameters, item);
       }
     }
@@ -229,7 +229,7 @@ return new BbPromise((resolve, reject) => {
       }
     };
 
-    return new BbPromise((resolve, reject) => {
+return new BbPromise((resolve, reject) => {
       https.get(options, (res) => {
         let body = '';
 
@@ -261,7 +261,7 @@ return new BbPromise((resolve, reject) => {
       }
     };
 
-  return new BbPromise((resolve, reject) => {
+return new BbPromise((resolve, reject) => {
       this.serverless.cli.log('Pinging host status...');
       request(options, (err, res, body) => {
         if (err) {
@@ -497,60 +497,60 @@ return new BbPromise((resolve, reject) => {
     let options = {};
     const requestUrl = ` https://management.azure.com/subscriptions/${subscriptionId}/resourceGroups/${resourceGroupName}/providers/Microsoft.Web/sites/${functionAppName}/functions/synctriggers?api-version=2015-08-01`;
     options = {
-       'host': 'management.azure.com',
-       'method': 'post',
-       'body': {},
-       'url': requestUrl,
-       'json': true,
-       'headers': {
-         'Authorization': constants.bearer + principalCredentials.tokenCache._entries[0].accessToken,
-         'Accept': 'application/json,*/*'
-       }
-     };
+      'host': 'management.azure.com',
+      'method': 'post',
+      'body': {},
+      'url': requestUrl,
+      'json': true,
+      'headers': {
+        'Authorization': constants.bearer + principalCredentials.tokenCache._entries[0].accessToken,
+        'Accept': 'application/json,*/*'
+      }
+    };
 
 return new BbPromise((resolve, reject) => {
-        request(options, (err, res, body) => {
-          if (err) {
-            reject(err);
-          }
-          this.serverless.cli.log(`Syncing Triggers....Response statuscode: ${res.statusCode}`);
-          resolve(res);
-        });
+      request(options, (err, res, body) => {
+        if (err) {
+          reject(err);
+        }
+        this.serverless.cli.log(`Syncing Triggers....Response statuscode: ${res.statusCode}`);
+        resolve(res);
       });
+    });
 
   }
-  
+
   runKuduCommand (command) {
     this.serverless.cli.log(`Running Kudu command ${command}...`);
     let options = {};
     const requestUrl = `https://${functionAppName}${constants.scmDomain}${constants.scmCommandApiPath}`;
     let postBody = {
-    "command": command,
-    "dir": 'site\\wwwroot'
+      "command": command,
+      "dir": 'site\\wwwroot'
     }
     options = {
-       'host': functionAppName + constants.scmDomain,
-       'method': 'post',
-       'body': postBody,
-       'url': requestUrl,
-       'json': true,
-       'headers': {
-         'Authorization': constants.bearer + principalCredentials.tokenCache._entries[0].accessToken,
-         'Accept': 'application/json,*/*'
-       }
-     };
+      'host': functionAppName + constants.scmDomain,
+      'method': 'post',
+      'body': postBody,
+      'url': requestUrl,
+      'json': true,
+      'headers': {
+        'Authorization': constants.bearer + principalCredentials.tokenCache._entries[0].accessToken,
+        'Accept': 'application/json,*/*'
+      }
+    };
 return new BbPromise((resolve, reject) => {
-        request(options, (err, res, body) => {
-          if (err) {
-            reject(err);
-          }
-          resolve(res);
-        });
+      request(options, (err, res, body) => {
+        if (err) {
+          reject(err);
+        }
+        resolve(res);
       });
+    });
 
   }
 
- cleanUpFunctionsBeforeDeploy (serverlessFunctions) {
+  cleanUpFunctionsBeforeDeploy (serverlessFunctions) {
     const deleteFunctionPromises = [];
 
     deployedFunctionNames.forEach((functionName) => {
@@ -563,7 +563,7 @@ return new BbPromise((resolve, reject) => {
 return BbPromise.all(deleteFunctionPromises);
   }
 
-  deleteFunction (functionName) {
+  deleteFunction(functionName) {
     const requestUrl = `https://${functionAppName}${constants.scmVfsPath}${functionName}/?recursive=true`;
     const options = {
       'host': functionAppName + constants.scmDomain,
@@ -587,7 +587,9 @@ return new BbPromise((resolve, reject) => {
     });
   }
 
-  uploadPackageJson (functionName) {
+  uploadPackageJson () {
+    const packageJsonFilePath = path.join(this.serverless.config.servicePath, 'package.json');
+    this.serverless.cli.log(`Uploading pacakge.json ...`);
     const requestUrl = `https://${functionAppName}${constants.scmVfsPath}package.json`;
     const options = {
       'host': functionAppName + constants.scmDomain,
@@ -599,22 +601,27 @@ return new BbPromise((resolve, reject) => {
         'Content-Type': constants.jsonContentType
       }
     };
-    var packageJsonFilePath = path.join(this.serverless.config.servicePath, 'package.json');
-
+    
 return new BbPromise((resolve, reject) => {
-      fs.createReadStream(packageJsonFilePath)
-            .pipe(request.put(options, (err, res, body) => {
-              if (err) {
-                reject(err);
-              } else {
-                resolve('Package json file uploaded');
-              }
-            }));
+      if (fs.existsSync(packageJsonFilePath)) {
+        fs.createReadStream(packageJsonFilePath)
+        .pipe(request.put(options, (err, res, body) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve('Package json file uploaded');
+          }
+        }));
+      }
+      else{
+          resolve('Package json file does not exist');
+      }
     });
   }
 
-  createZipObject (functionName, entryPoint, filePath, params) {
-    return new BbPromise((resolve, reject) => {
+  createZipObjectAndUploadFunction (functionName, entryPoint, filePath, params) {
+
+return new BbPromise((resolve, reject) => {
       this.serverless.cli.log(`Packaging function: ${functionName}`);
       const folderForJSFunction = path.join(functionsFolder, functionName);
       const handlerPath = path.join(this.serverless.config.servicePath, filePath);
@@ -631,55 +638,12 @@ return new BbPromise((resolve, reject) => {
 
       functionJSON.entryPoint = entryPoint;
       fs.writeFileSync(path.join(folderForJSFunction, 'function.json'), JSON.stringify(functionJSON, null, 4));
-      fs.readdirSync(functionsFolder).filter((folder) => {
-        const folderName = path.basename(folder);
-
-        if (fs.statSync(path.join(functionsFolder, folder)).isDirectory() && functionName == folderName) {
-          const zip = new JSZip();
-
-          fs.readdir(path.join(functionsFolder, folder), (err, files) => {
-            if (err) {
-              reject(err);
-            } else {
-              let filesInFolder = 0;
-
-              for (let i = 0; i < files.length; i++) {
-                const filepathtobezipped = path.join(functionsFolder, folder, files[i]);
-                const data = fs.readFileSync(filepathtobezipped);
-
-                filesInFolder++;
-                zip.folder(path.basename(folder)).folder(path.basename(folder)).file(path.basename(filepathtobezipped), data);
-                if (filesInFolder === files.length) {
-                  zipArray.push({
-                    'key': path.basename(folder),
-                    'value': zip
-                  });
-                  resolve(`done folder..${folder}`);
-                }
-              }
-            }
-          });
-        }
-      });
-    });
-  }
-
-  createZipFileAndUploadFunction (folder, zip) {
-    return new BbPromise((resolve, reject) => {
-      const generateOptions = {
-        'type': 'nodebuffer',
-        'streamFiles': true
-      };
-      const zipFileName = `${path.basename(folder)}.zip`;
-      const outputZipPath = path.join(functionsFolder, zipFileName);
-
-      zip.folder(path.basename(folder)).generateNodeStream(generateOptions)
-        .pipe(fs.createWriteStream(outputZipPath))
-        .on('error', (error) => {
-          reject(error);
-        })
-        .on('finish', () => {
-          const requestUrl = `https://${functionAppName}${constants.scmZipApiPath}`;
+      const functionZipFile = path.join(functionsFolder, functionName + '.zip');
+      zipFolder(folderForJSFunction, functionZipFile, function (createZipErr) {
+        if (createZipErr) {
+          reject(createZipErr);
+        } else {
+          const requestUrl = `https://${functionAppName}${constants.scmZipApiPath}/${functionName}/`;
           const options = {
             'url': requestUrl,
             'headers': {
@@ -688,27 +652,18 @@ return new BbPromise((resolve, reject) => {
             }
           };
 
-          fs.createReadStream(outputZipPath)
-            .pipe(request.put(options, (err, res, body) => {
-              if (err) {
-                reject(err);
+          fs.createReadStream(functionZipFile)
+            .pipe(request.put(options, (uploadZipErr, uploadZipResponse, body) => {
+              if (uploadZipErr) {
+                reject(uploadZipErr);
               } else {
-                resolve('ZipFileCreated and uploaded');
+                fse.removeSync(functionZipFile);
+                resolve(uploadZipResponse);
               }
-              fse.removeSync(outputZipPath);
             }));
-        });
+        }
+      });
     });
-  }
-
-  createAndUploadZipFunctions () {
-    const zipFunctions = [];
-
-    for (let j = 0; j < zipArray.length; j++) {
-      zipFunctions.push(this.createZipFileAndUploadFunction(zipArray[j].key, zipArray[j].value));
-    }
-
-return BbPromise.all(zipFunctions);
   }
 }
 module.exports = AzureProvider;


### PR DESCRIPTION
This PR addresses two limitations with the way the `invoke` command currently handles function parameters:

1. It adds support for specifying the JSON config as a string literal (via the `-d` flag), in addition to the file-based support (via the `-p` flag).   

   ```shell
    serverless invoke -f hello -d '{"name":"JC"}'
   ```

2. It adds support for specifying multiple parameters (properties) in the provided JSON config (inline or file). Otherwise, `invoke` would only send the last parameter to the function invocation.

Some of the churn in the PR is related to formatting, which I did to improve the code folding support in VS Code (or other editors that rely on indentation).