### PR TITLE
Changes for Issues 44, 46 and 48

### DIFF
--- a/deploy/azureDeploy.js
+++ b/deploy/azureDeploy.js
@@ -20,10 +20,6 @@ class AzureDeploy {
       createFunctions
     );
 
-    if(this.options.preserve) {
-      this.serverless.config.preserveDeployedFunctions = true;
-    }
-
     this.hooks = {
       'before:deploy:deploy': () => BbPromise.bind(this)
         .then(this.loginToAzure)

--- a/deploy/azureDeploy.js
+++ b/deploy/azureDeploy.js
@@ -20,6 +20,10 @@ class AzureDeploy {
       createFunctions
     );
 
+    if(this.options.preserve) {
+      this.serverless.config.preserveDeployedFunctions = true;
+    }
+
     this.hooks = {
       'before:deploy:deploy': () => BbPromise.bind(this)
         .then(this.loginToAzure)

--- a/deploy/azureDeployFunction.js
+++ b/deploy/azureDeployFunction.js
@@ -10,6 +10,10 @@ class AzureDeployFunction {
     this.options = options;
     this.provider = this.serverless.getProvider('azure');
 
+    if(this.options.preserve) {
+      this.serverless.config.preserveDeployedFunctions = true;
+    }
+
     Object.assign(
       this,
       loginToAzure,

--- a/deploy/lib/CreateResourceGroupAndFunctionApp.js
+++ b/deploy/lib/CreateResourceGroupAndFunctionApp.js
@@ -1,9 +1,10 @@
 'use strict';
 
 module.exports = {
-  CreateResourceGroupAndFunctionApp () {
+  CreateResourceGroupAndFunctionApp() {
+    this.provider.initialise(this.serverless, this.options);
 
-return this.provider.CreateResourceGroup()
+    return this.provider.CreateResourceGroup()
       .then(() => this.provider.CreateFunctionApp());
   }
 };

--- a/deploy/lib/cleanUpFunctions.js
+++ b/deploy/lib/cleanUpFunctions.js
@@ -2,6 +2,8 @@
 
 module.exports = {
   cleanUpFunctions () {
+    this.provider.initialise(this.serverless, this.options);
+
     return this.provider.isExistingFunctionApp()
       .then(() => this.provider.getDeployedFunctionsNames())
       .then(() => {

--- a/deploy/lib/cleanUpFunctions.js
+++ b/deploy/lib/cleanUpFunctions.js
@@ -4,6 +4,13 @@ module.exports = {
   cleanUpFunctions () {
     return this.provider.isExistingFunctionApp()
       .then(() => this.provider.getDeployedFunctionsNames())
-      .then(() => this.provider.cleanUpFunctionsBeforeDeploy(this.serverless.service.getAllFunctions()));
+      .then(() => {
+        if (this.serverless.config && this.serverless.config.preserveDeployedFunctions) {
+          this.serverless.cli.log(`Skipping cleaning of existing functions as '--preserve' has been specified.`);
+          return;
+        }
+
+        this.provider.deleteFunctionsExcluding(this.serverless.service.getAllFunctions());
+      });
   }
 };

--- a/deploy/lib/cleanUpFunctions.js
+++ b/deploy/lib/cleanUpFunctions.js
@@ -7,7 +7,7 @@ module.exports = {
     return this.provider.isExistingFunctionApp()
       .then(() => this.provider.getDeployedFunctionsNames())
       .then(() => {
-        if (this.serverless.config && this.serverless.config.preserveDeployedFunctions) {
+        if (this.options.preserve) {
           this.serverless.cli.log(`Skipping cleaning of existing functions as '--preserve' has been specified.`);
           return;
         }

--- a/deploy/lib/createFunction.js
+++ b/deploy/lib/createFunction.js
@@ -3,11 +3,13 @@
 const utils = require('../../shared/utils');
 
 module.exports = {
-  createFunction () {
+  createFunction() {
+    this.provider.initialise(this.serverless, this.options);
+
     const functionName = this.options.function;
     const metaData = utils.getFunctionMetaData(functionName, this.provider.getParsedBindings(), this.serverless);
 
-return this.provider.createZipObject(functionName, metaData.entryPoint, metaData.handlerPath, metaData.params)
+    return this.provider.createZipObject(functionName, metaData.entryPoint, metaData.handlerPath, metaData.params)
       .then(() => this.provider.createAndUploadZipFunctions())
       .then(() => this.provider.syncTriggers());
   }

--- a/deploy/lib/createFunctions.js
+++ b/deploy/lib/createFunctions.js
@@ -4,7 +4,9 @@ const BbPromise = require('bluebird');
 const utils = require('../../shared/utils');
 
 module.exports = {
-  createFunctions () {
+  createFunctions() {
+    this.provider.initialise(this.serverless, this.options);
+
     const createFunctionPromises = [];
 
     this.serverless.service.getAllFunctions().forEach((functionName) => {
@@ -14,10 +16,10 @@ module.exports = {
     });
 
     return BbPromise.all(createFunctionPromises)
-            .then(() => this.provider.createAndUploadZipFunctions())
-            .then(() => this.provider.syncTriggers())
-            .then(() => this.provider.runKuduCommand('del package.json'))
-            .then(() => this.provider.uploadPackageJson())
-            .then(() => this.provider.runKuduCommand('npm install --production'));
+      .then(() => this.provider.createAndUploadZipFunctions())
+      .then(() => this.provider.syncTriggers())
+      .then(() => this.provider.runKuduCommand('del package.json'))
+      .then(() => this.provider.uploadPackageJson())
+      .then(() => this.provider.runKuduCommand('npm install --production'));
   }
 };

--- a/index.js
+++ b/index.js
@@ -19,7 +19,8 @@ class AzureIndex {
     this.serverless = serverless;
     this.options = options;
 
-    this.serverless.pluginManager.addPlugin(AzureProvider);
+    this.serverless.setProvider(AzureProvider.getProviderName(), new AzureProvider(this.serverless));
+
     this.serverless.pluginManager.addPlugin(AzureDeploy);
     this.serverless.pluginManager.addPlugin(AzureDeployFunction);
     this.serverless.pluginManager.addPlugin(AzureInvoke);

--- a/index.js
+++ b/index.js
@@ -19,9 +19,6 @@ class AzureIndex {
     this.serverless = serverless;
     this.options = options;
 
-    // if we do this before the addPlugin calls then these options will be passed through to each of the plugins
-    this.serverless.pluginManager.setCliOptions(options);
-
     this.serverless.pluginManager.addPlugin(AzureProvider);
     this.serverless.pluginManager.addPlugin(AzureDeploy);
     this.serverless.pluginManager.addPlugin(AzureDeployFunction);

--- a/index.js
+++ b/index.js
@@ -19,7 +19,7 @@ class AzureIndex {
     this.serverless = serverless;
     this.options = options;
 
-    // if we do this before the addPlugin calls then these options will be passed through
+    // if we do this before the addPlugin calls then these options will be passed through to each of the plugins
     this.serverless.pluginManager.setCliOptions(options);
 
     this.serverless.pluginManager.addPlugin(AzureProvider);

--- a/index.js
+++ b/index.js
@@ -19,6 +19,9 @@ class AzureIndex {
     this.serverless = serverless;
     this.options = options;
 
+    // if we do this before the addPlugin calls then these options will be passed through
+    this.serverless.pluginManager.setCliOptions(options);
+
     this.serverless.pluginManager.addPlugin(AzureProvider);
     this.serverless.pluginManager.addPlugin(AzureDeploy);
     this.serverless.pluginManager.addPlugin(AzureDeployFunction);

--- a/invoke/lib/invokeFunction.js
+++ b/invoke/lib/invokeFunction.js
@@ -1,11 +1,13 @@
 'use strict';
 
 module.exports = {
-  invokeFunction () {
+  invokeFunction() {
+    this.provider.initialise(this.serverless, this.options);
+
     const func = this.options.function;
     const functionObject = this.serverless.service.getFunction(func);
     const eventType = Object.keys(functionObject.events[0])[0];
-    
+
     return this.provider.invoke(func, eventType, this.options.data);
     // TODO: Github issue: https://github.com/Azure/azure-webjobs-sdk-script/issues/1122
     // .then(() => this.provider.getInvocationId(func))

--- a/logs/lib/retrieveLogs.js
+++ b/logs/lib/retrieveLogs.js
@@ -1,10 +1,12 @@
 'use strict';
 
 module.exports = {
-  retrieveLogs () {
+  retrieveLogs() {
+    this.provider.initialise(this.serverless, this.options);
+
     const functionName = this.options.function;
 
-return this.provider.getAdminKey()
+    return this.provider.getAdminKey()
       .then(() => this.provider.pingHostStatus(functionName))
       .then(() => this.provider.getLogsStream(functionName));
   }

--- a/provider/armTemplates/azuredeploy.json
+++ b/provider/armTemplates/azuredeploy.json
@@ -8,6 +8,9 @@
                 "description": "The name of the function app that you wish to create."
             }
         },
+        "hostingPlanName": {
+            "type" : "string"
+        },
         "storageAccountType": {
             "type": "string",
             "defaultValue": "Standard_LRS",
@@ -23,7 +26,6 @@
         }        
     },
     "variables": {
-        "hostingPlanName": "[concat(parameters('functionAppName'), '-hosting')]",
         "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'azfunctions')]"
     },
     "resources": [
@@ -39,10 +41,10 @@
         {
             "type": "Microsoft.Web/serverfarms",
             "apiVersion": "2015-04-01",
-            "name": "[variables('hostingPlanName')]",
+            "name": "[parameters('hostingPlanName')]",
             "location": "[resourceGroup().location]",
             "properties": {
-                "name": "[variables('hostingPlanName')]",
+                "name": "[parameters('hostingPlanName')]",
                 "computeMode": "Dynamic",
                 "sku": "Dynamic"
             }
@@ -55,10 +57,10 @@
             "kind": "functionapp",
             "properties": {
                 "name": "[parameters('functionAppName')]",
-                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]"
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', parameters('hostingPlanName'))]"
             },
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]",
+                "[resourceId('Microsoft.Web/serverfarms', parameters('hostingPlanName'))]",
                 "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
             ],
             "resources": [

--- a/provider/armTemplates/azuredeploy.json
+++ b/provider/armTemplates/azuredeploy.json
@@ -75,6 +75,8 @@
                     "properties": {
                         "AzureWebJobsStorage": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('storageAccountName'),';AccountKey=',listkeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2015-05-01-preview').key1,';')]",
                         "AzureWebJobsDashboard": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('storageAccountName'),';AccountKey=',listkeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2015-05-01-preview').key1,';')]",
+                        "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('storageAccountName'),';AccountKey=',listkeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2015-05-01-preview').key1,';')]",
+                        "WEBSITE_CONTENTSHARE": "[parameters('functionAppName')]",
                         "FUNCTIONS_EXTENSION_VERSION": "~1"
                     }
                 }

--- a/provider/armTemplates/azuredeploy.json
+++ b/provider/armTemplates/azuredeploy.json
@@ -23,8 +23,7 @@
         }        
     },
     "variables": {
-        "functionAppName": "[parameters('functionAppName')]",
-        "hostingPlanName": "[parameters('functionAppName')]",
+        "hostingPlanName": "[concat(parameters('functionAppName'), '-hosting')]",
         "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'azfunctions')]"
     },
     "resources": [
@@ -51,11 +50,11 @@
         {
             "apiVersion": "2015-08-01",
             "type": "Microsoft.Web/sites",
-            "name": "[variables('functionAppName')]",
+            "name": "[parameters('functionAppName')]",
             "location": "[resourceGroup().location]",
             "kind": "functionapp",
             "properties": {
-                "name": "[variables('functionAppName')]",
+                "name": "[parameters('functionAppName')]",
                 "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]"
             },
             "dependsOn": [
@@ -68,7 +67,7 @@
                     "name": "appsettings",
                     "type": "config",
                     "dependsOn": [
-                        "[resourceId('Microsoft.Web/sites', variables('functionAppName'))]",
+                        "[resourceId('Microsoft.Web/sites', parameters('functionAppName'))]",
                         "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
                     ],
                     "properties": {

--- a/provider/armTemplates/azuredeployWithGit.json
+++ b/provider/armTemplates/azuredeployWithGit.json
@@ -82,6 +82,9 @@
                     "properties": {
                         "AzureWebJobsStorage": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('storageAccountName'),';AccountKey=',listkeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2015-05-01-preview').key1,';')]",
                         "AzureWebJobsDashboard": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('storageAccountName'),';AccountKey=',listkeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2015-05-01-preview').key1,';')]",
+                        "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING": "[concat('DefaultEndpointsProtocol=https;AccountName=',variables('storageAccountName'),';AccountKey=',listkeys(resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName')), '2015-05-01-preview').key1,';')]",
+                        "WEBSITE_CONTENTSHARE": "[parameters('functionAppName')]",
+                     
                         "FUNCTIONS_EXTENSION_VERSION": "~1"
                     }
                 },

--- a/provider/armTemplates/azuredeployWithGit.json
+++ b/provider/armTemplates/azuredeployWithGit.json
@@ -8,6 +8,9 @@
                 "description": "The name of the function app that you wish to create."
             }
         },
+        "hostingPlanName": {
+            "type" : "string"
+        },        
         "storageAccountType": {
             "type": "string",
             "defaultValue": "Standard_LRS",
@@ -29,8 +32,6 @@
         }
     },
     "variables": {
-        "functionAppName": "[parameters('functionAppName')]",
-        "hostingPlanName": "[parameters('functionAppName')]",
         "gitRepoUrl": "[parameters('gitUrl')]",
         "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'azfunctions')]"
     },
@@ -47,10 +48,10 @@
         {
             "type": "Microsoft.Web/serverfarms",
             "apiVersion": "2015-04-01",
-            "name": "[variables('hostingPlanName')]",
+            "name": "[parameters('hostingPlanName')]",
             "location": "[resourceGroup().location]",
             "properties": {
-                "name": "[variables('hostingPlanName')]",
+                "name": "[parameters('hostingPlanName')]",
                 "computeMode": "Dynamic",
                 "sku": "Dynamic"
             }
@@ -58,15 +59,15 @@
         {
             "apiVersion": "2015-08-01",
             "type": "Microsoft.Web/sites",
-            "name": "[variables('functionAppName')]",
+            "name": "[parameters('functionAppName')]",
             "location": "[resourceGroup().location]",
             "kind": "functionapp",
             "properties": {
-                "name": "[variables('functionAppName')]",
-                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]"
+                "name": "[parameters('functionAppName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', parameters('hostingPlanName'))]"
             },
             "dependsOn": [
-                "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]",
+                "[resourceId('Microsoft.Web/serverfarms', parameters('hostingPlanName'))]",
                 "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
             ],
             "resources": [
@@ -75,7 +76,7 @@
                     "name": "appsettings",
                     "type": "config",
                     "dependsOn": [
-                        "[resourceId('Microsoft.Web/sites', variables('functionAppName'))]",
+                        "[resourceId('Microsoft.Web/sites', parameters('functionAppName'))]",
                         "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
                     ],
                     "properties": {
@@ -89,7 +90,7 @@
                     "name": "web",
                     "type": "sourcecontrols",
                     "dependsOn": [
-                        "[resourceId('Microsoft.Web/sites', variables('functionAppName'))]"
+                        "[resourceId('Microsoft.Web/sites', parameters('functionAppName'))]"
                     ],
                     "properties": {
                         "repoUrl": "[variables('gitRepoUrl')]",

--- a/provider/azureProvider.js
+++ b/provider/azureProvider.js
@@ -68,11 +68,26 @@ class AzureProvider {
     this.serverless = serverless;
     this.provider = this;
     this.serverless.setProvider(constants.providerName, this);
-    subscriptionId = this.getSetting(azureCredentials.azureSubId);
-    servicePrincipalTenantId = this.getSetting(azureCredentials.azureServicePrincipalTenantId);
-    servicePrincipalClientId = this.getSetting(azureCredentials.azureservicePrincipalClientId);
-    servicePrincipalPassword = this.getSetting(azureCredentials.azureServicePrincipalPassword);
+  }
 
+  initialise(serverless, options) {
+    this.serverless = serverless;
+    this.options = options;
+
+    if(this.serverless.service.provider.credentials) {
+      var credentials = this.serverless.service.provider.credentials;
+
+      subscriptionId = credentials.azureSubId;
+      servicePrincipalTenantId = credentials.azureServicePrincipalTenantId;
+      servicePrincipalClientId = credentials.azureServicePrincipalClientId;
+      servicePrincipalPassword = credentials.azureServicePrincipalPassword;
+    }
+    else {
+      subscriptionId = this.getSetting(azureCredentials.azureSubId);
+      servicePrincipalTenantId = this.getSetting(azureCredentials.azureServicePrincipalTenantId);
+      servicePrincipalClientId = this.getSetting(azureCredentials.azureservicePrincipalClientId);
+      servicePrincipalPassword = this.getSetting(azureCredentials.azureServicePrincipalPassword);
+    }
 
     functionAppName = this.serverless.service.service;
     if(this.serverless.service.provider.functionAppName) {
@@ -86,12 +101,14 @@ class AzureProvider {
 
     resourceGroupName = `${functionAppName}-rg`;
     if (this.serverless.service.provider.resourceGroup) {
-      this.isDefaultResourceGroup = false;
+      isDefaultResourceGroup = false;
       resourceGroupName = this.serverless.service.provider.resourceGroup;
     }
 
     deploymentName = `${resourceGroupName}-deployment`;
     functionsFolder = path.join(this.serverless.config.servicePath, 'functions');
+
+    return this;
   }
 
   getParsedBindings() {
@@ -152,7 +169,7 @@ class AzureProvider {
   CreateFunctionApp(method, params) {
     this.serverless.cli.log(`Creating function app: ${functionAppName}`);
     const resourceClient = new resourceManagement.ResourceManagementClient(principalCredentials, subscriptionId);
-    let parameters = { 'functionAppName': { 'value': functionAppName } };
+    let parameters = { 'functionAppName': { 'value': functionAppName }, 'hostingPlanName': {'value':hostingPlanName} };
 
     const gitUrl = this.serverless.service.provider.gitUrl;
 

--- a/provider/azureProvider.js
+++ b/provider/azureProvider.js
@@ -71,8 +71,20 @@ class AzureProvider {
     servicePrincipalClientId = this.getSetting(azureCredentials.azureservicePrincipalClientId);
     servicePrincipalPassword = this.getSetting(azureCredentials.azureServicePrincipalPassword);
 
-    functionAppName = this.serverless.service.service;
-    resourceGroupName = `${functionAppName}-rg`;
+    if(this.serverless.service.provider.application) {
+      functionAppName = this.serverless.service.provider.application;
+    }
+    else {
+      functionAppName = this.serverless.service.service;
+    }
+
+    if(this.serverless.service.provider.resourceGroup) {
+      resourceGroupName = this.serverless.service.provider.resourceGroup;
+    }
+    else {
+      resourceGroupName = `${functionAppName}-rg`;
+    }
+
     deploymentName = `${resourceGroupName}-deployment`;
     functionsFolder = path.join(this.serverless.config.servicePath, 'functions');
   }

--- a/provider/azureProvider.js
+++ b/provider/azureProvider.js
@@ -58,11 +58,11 @@ const azureCredentials = {
 };
 
 class AzureProvider {
-  static getProviderName () {
+  static getProviderName() {
     return constants.providerName;
   }
 
-  constructor (serverless) {
+  constructor(serverless) {
     this.serverless = serverless;
     this.provider = this;
     this.serverless.setProvider(constants.providerName, this);
@@ -71,14 +71,9 @@ class AzureProvider {
     servicePrincipalClientId = this.getSetting(azureCredentials.azureservicePrincipalClientId);
     servicePrincipalPassword = this.getSetting(azureCredentials.azureServicePrincipalPassword);
 
-    if(this.serverless.service.provider.application) {
-      functionAppName = this.serverless.service.provider.application;
-    }
-    else {
-      functionAppName = this.serverless.service.service;
-    }
+    functionAppName = this.serverless.service.service;
 
-    if(this.serverless.service.provider.resourceGroup) {
+    if (this.serverless.service.provider.resourceGroup) {
       resourceGroupName = this.serverless.service.provider.resourceGroup;
     }
     else {
@@ -89,26 +84,26 @@ class AzureProvider {
     functionsFolder = path.join(this.serverless.config.servicePath, 'functions');
   }
 
-  getParsedBindings () {
+  getParsedBindings() {
     if (!this.parsedBindings) {
       this.parsedBindings = parseBindings.getBindingsMetaData(this.serverless);
     }
 
-return this.parsedBindings;
+    return this.parsedBindings;
   }
 
   getSetting(key) {
     // Loop through environment variables looking for the keys, case insentivie
     for (var k in process.env) {
       if (process.env.hasOwnProperty(k)) {
-        if(k.toLowerCase() === key.toLowerCase()) {
+        if (k.toLowerCase() === key.toLowerCase()) {
           return process.env[k];
         }
       }
     }
   }
 
-  LoginWithServicePrincipal () {
+  LoginWithServicePrincipal() {
     return new BbPromise((resolve, reject) => {
       msRestAzure.loginWithServicePrincipalSecret(servicePrincipalClientId, servicePrincipalPassword, servicePrincipalTenantId, (error, credentials) => {
         if (error) {
@@ -121,16 +116,16 @@ return this.parsedBindings;
     });
   }
 
-  CreateResourceGroup () {
+  CreateResourceGroup() {
     const groupParameters = {
-'location': this.serverless.service.provider.location,
-'tags': {'sampletag': 'sampleValue'}
-};
+      'location': this.serverless.service.provider.location,
+      'tags': { 'sampletag': 'sampleValue' }
+    };
 
     this.serverless.cli.log(`Creating resource group: ${resourceGroupName}`);
     const resourceClient = new resourceManagement.ResourceManagementClient(principalCredentials, subscriptionId);
 
-return new BbPromise((resolve, reject) => {
+    return new BbPromise((resolve, reject) => {
       resourceClient.resourceGroups.createOrUpdate(resourceGroupName,
         groupParameters, (error, result, createOrUpdateRequest, response) => {
           if (error) {
@@ -142,17 +137,17 @@ return new BbPromise((resolve, reject) => {
     });
   }
 
-  CreateFunctionApp (method, params) {
+  CreateFunctionApp(method, params) {
     this.serverless.cli.log(`Creating function app: ${functionAppName}`);
     const resourceClient = new resourceManagement.ResourceManagementClient(principalCredentials, subscriptionId);
-    let parameters = {'functionAppName': {'value': functionAppName}};
+    let parameters = { 'functionAppName': { 'value': functionAppName } };
 
     const gitUrl = this.serverless.service.provider.gitUrl;
 
     if (gitUrl) {
       parameters = {
-        'functionAppName': {'value': functionAppName},
-        'gitUrl': {'value': gitUrl}
+        'functionAppName': { 'value': functionAppName },
+        'gitUrl': { 'value': gitUrl }
       };
     }
 
@@ -169,7 +164,7 @@ return new BbPromise((resolve, reject) => {
       for (let paramIndex = 0; paramIndex < userParametersKeys.length; paramIndex++) {
         const item = {};
 
-        item[userParametersKeys[paramIndex]] = {'value': userParameters[userParametersKeys[paramIndex]]};
+        item[userParametersKeys[paramIndex]] = { 'value': userParameters[userParametersKeys[paramIndex]] };
         parameters = _.merge(parameters, item);
       }
     }
@@ -183,7 +178,7 @@ return new BbPromise((resolve, reject) => {
       }
     };
 
-return new BbPromise((resolve, reject) => {
+    return new BbPromise((resolve, reject) => {
       resourceClient.deployments.createOrUpdate(resourceGroupName,
         deploymentName,
         deploymentParameters, (error, result, createOrUpdateRequest, response) => {
@@ -199,11 +194,11 @@ return new BbPromise((resolve, reject) => {
     });
   }
 
-  DeleteDeployment () {
+  DeleteDeployment() {
     this.serverless.cli.log(`Deleting deployment: ${deploymentName}`);
     const resourceClient = new resourceManagement.ResourceManagementClient(principalCredentials, subscriptionId);
 
-return new BbPromise((resolve, reject) => {
+    return new BbPromise((resolve, reject) => {
       resourceClient.deployments.deleteMethod(resourceGroupName,
         deploymentName, (error, result, deleteRequest, response) => {
           if (error) {
@@ -215,11 +210,11 @@ return new BbPromise((resolve, reject) => {
     });
   }
 
-  DeleteResourceGroup () {
+  DeleteResourceGroup() {
     this.serverless.cli.log(`Deleting resource group: ${resourceGroupName}`);
     const resourceClient = new resourceManagement.ResourceManagementClient(principalCredentials, subscriptionId);
 
-return new BbPromise((resolve, reject) => {
+    return new BbPromise((resolve, reject) => {
       resourceClient.resourceGroups.deleteMethod(resourceGroupName, (error, result, deleteRequest, response) => {
         if (error) {
           reject(error);
@@ -230,7 +225,7 @@ return new BbPromise((resolve, reject) => {
     });
   }
 
-  getAdminKey () {
+  getAdminKey() {
     const options = {
       'host': functionAppName + constants.scmDomain,
       'port': 443,
@@ -261,7 +256,7 @@ return new BbPromise((resolve, reject) => {
     });
   }
 
-  pingHostStatus (functionName) {
+  pingHostStatus(functionName) {
     const requestUrl = `https://${functionAppName}${constants.functionAppDomain}/admin/functions/${functionName}/status`;
     const options = {
       'host': functionAppName + constants.functionAppDomain,
@@ -273,7 +268,7 @@ return new BbPromise((resolve, reject) => {
       }
     };
 
-  return new BbPromise((resolve, reject) => {
+    return new BbPromise((resolve, reject) => {
       this.serverless.cli.log('Pinging host status...');
       request(options, (err, res, body) => {
         if (err) {
@@ -285,10 +280,10 @@ return new BbPromise((resolve, reject) => {
     });
   }
 
-  isExistingFunctionApp () {
+  isExistingFunctionApp() {
     const host = functionAppName + constants.scmDomain;
 
-return new BbPromise((resolve, reject) => {
+    return new BbPromise((resolve, reject) => {
       dns.resolve4(host, (err, addresses) => {
         if (err) {
           if (err.message.includes('ENOTFOUND')) {
@@ -304,7 +299,7 @@ return new BbPromise((resolve, reject) => {
     });
   }
 
-  getDeployedFunctionsNames () {
+  getDeployedFunctionsNames() {
     const requestUrl = `https://${functionAppName}${constants.scmDomain}${constants.functionsApiPath}`;
     const options = {
       'host': functionAppName + constants.scmDomain,
@@ -316,7 +311,7 @@ return new BbPromise((resolve, reject) => {
       }
     };
 
-return new BbPromise((resolve, reject) => {
+    return new BbPromise((resolve, reject) => {
       if (existingFunctionApp) {
         this.serverless.cli.log('Looking for deployed functions that are not part of the current deployment...');
         request(options, (err, res, body) => {
@@ -343,7 +338,7 @@ return new BbPromise((resolve, reject) => {
     });
   }
 
-  getLogsStream (functionName) {
+  getLogsStream(functionName) {
     const logOptions = {
       'host': functionAppName + constants.scmDomain,
       'port': 443,
@@ -374,7 +369,7 @@ return new BbPromise((resolve, reject) => {
     });
   }
 
-  getInvocationId (functionName) {
+  getInvocationId(functionName) {
     const options = {
       'host': functionAppName + constants.scmDomain,
       'port': 443,
@@ -385,7 +380,7 @@ return new BbPromise((resolve, reject) => {
       }
     };
 
-return new BbPromise((resolve, reject) => {
+    return new BbPromise((resolve, reject) => {
       https.get(options, (res) => {
         let body = '';
 
@@ -405,7 +400,7 @@ return new BbPromise((resolve, reject) => {
     });
   }
 
-  getLogsForInvocationId () {
+  getLogsForInvocationId() {
     this.serverless.cli.log(`Logs for InvocationId: ${invocationId}`);
     const options = {
       'host': functionAppName + constants.scmDomain,
@@ -417,7 +412,7 @@ return new BbPromise((resolve, reject) => {
       }
     };
 
-return new BbPromise((resolve, reject) => {
+    return new BbPromise((resolve, reject) => {
       https.get(options, (res) => {
         let body = '';
 
@@ -435,7 +430,7 @@ return new BbPromise((resolve, reject) => {
     });
   }
 
-  invoke (functionName, eventType, eventData) {
+  invoke(functionName, eventType, eventData) {
     let options = {};
 
     if (eventType === 'http') {
@@ -454,7 +449,7 @@ return new BbPromise((resolve, reject) => {
         'path': `${constants.functionAppApiPath + functionName}?${queryString}`
       };
 
-return new BbPromise((resolve, reject) => {
+      return new BbPromise((resolve, reject) => {
         https.get(options, (res) => {
           let body = '';
 
@@ -471,103 +466,101 @@ return new BbPromise((resolve, reject) => {
         });
       });
     }
-      const requestUrl = `https://${functionAppName}${constants.functionsAdminApiPath}${functionName}`;
-      
-      options = {
-        'host': constants.functionAppDomain,
-        'method': 'post',
-        'body': eventData,
-        'url': requestUrl,
-        'json': true,
-        'headers': {
-          'x-functions-key': functionsAdminKey,
-          'Accept': 'application/json,*/*'
-        }
-      };
+    const requestUrl = `https://${functionAppName}${constants.functionsAdminApiPath}${functionName}`;
 
-return new BbPromise((resolve, reject) => {
-        request(options, (err, res, body) => {
-          if (err) {
-            reject(err);
-          }
-          this.serverless.cli.log(`Invoked function at: ${requestUrl}. \nResponse statuscode: ${res.statusCode}`);
-          resolve(res);
-        });
+    options = {
+      'host': constants.functionAppDomain,
+      'method': 'post',
+      'body': eventData,
+      'url': requestUrl,
+      'json': true,
+      'headers': {
+        'x-functions-key': functionsAdminKey,
+        'Accept': 'application/json,*/*'
+      }
+    };
+
+    return new BbPromise((resolve, reject) => {
+      request(options, (err, res, body) => {
+        if (err) {
+          reject(err);
+        }
+        this.serverless.cli.log(`Invoked function at: ${requestUrl}. \nResponse statuscode: ${res.statusCode}`);
+        resolve(res);
       });
+    });
 
   }
 
-  syncTriggers () {
+  syncTriggers() {
     let options = {};
     const requestUrl = ` https://management.azure.com/subscriptions/${subscriptionId}/resourceGroups/${resourceGroupName}/providers/Microsoft.Web/sites/${functionAppName}/functions/synctriggers?api-version=2015-08-01`;
     options = {
-       'host': 'management.azure.com',
-       'method': 'post',
-       'body': {},
-       'url': requestUrl,
-       'json': true,
-       'headers': {
-         'Authorization': constants.bearer + principalCredentials.tokenCache._entries[0].accessToken,
-         'Accept': 'application/json,*/*'
-       }
-     };
+      'host': 'management.azure.com',
+      'method': 'post',
+      'body': {},
+      'url': requestUrl,
+      'json': true,
+      'headers': {
+        'Authorization': constants.bearer + principalCredentials.tokenCache._entries[0].accessToken,
+        'Accept': 'application/json,*/*'
+      }
+    };
 
-return new BbPromise((resolve, reject) => {
-        request(options, (err, res, body) => {
-          if (err) {
-            reject(err);
-          }
-          this.serverless.cli.log(`Syncing Triggers....Response statuscode: ${res.statusCode}`);
-          resolve(res);
-        });
+    return new BbPromise((resolve, reject) => {
+      request(options, (err, res, body) => {
+        if (err) {
+          reject(err);
+        }
+        this.serverless.cli.log(`Syncing Triggers....Response statuscode: ${res.statusCode}`);
+        resolve(res);
       });
+    });
 
   }
-  
-  runKuduCommand (command) {
+
+  runKuduCommand(command) {
     this.serverless.cli.log(`Running Kudu command ${command}...`);
     let options = {};
     const requestUrl = `https://${functionAppName}${constants.scmDomain}${constants.scmCommandApiPath}`;
     let postBody = {
-    "command": command,
-    "dir": 'site\\wwwroot'
+      "command": command,
+      "dir": 'site\\wwwroot'
     }
     options = {
-       'host': functionAppName + constants.scmDomain,
-       'method': 'post',
-       'body': postBody,
-       'url': requestUrl,
-       'json': true,
-       'headers': {
-         'Authorization': constants.bearer + principalCredentials.tokenCache._entries[0].accessToken,
-         'Accept': 'application/json,*/*'
-       }
-     };
-return new BbPromise((resolve, reject) => {
-        request(options, (err, res, body) => {
-          if (err) {
-            reject(err);
-          }
-          resolve(res);
-        });
-      });
-
-  }
-
- cleanUpFunctionsBeforeDeploy (serverlessFunctions) {
-    const deleteFunctionPromises = [];
-
-    deployedFunctionNames.forEach((functionName) => {
-      if (serverlessFunctions.indexOf(functionName) < 0) {
-        this.serverless.cli.log(`Deleting function : ${functionName}`);
-        deleteFunctionPromises.push(this.deleteFunction(functionName));
+      'host': functionAppName + constants.scmDomain,
+      'method': 'post',
+      'body': postBody,
+      'url': requestUrl,
+      'json': true,
+      'headers': {
+        'Authorization': constants.bearer + principalCredentials.tokenCache._entries[0].accessToken,
+        'Accept': 'application/json,*/*'
       }
+    };
+    return new BbPromise((resolve, reject) => {
+      request(options, (err, res, body) => {
+        if (err) {
+          reject(err);
+        }
+        resolve(res);
+      });
     });
 
-return BbPromise.all(deleteFunctionPromises);
   }
 
-  deleteFunction (functionName) {
+  cleanUpFunctionsBeforeDeploy(serverlessFunctions) {
+    const deleteFunctionPromises = [];
+
+    // delete all functions from the service that are about to be deployed.
+    serverlessFunctions.forEach((functionName) => {
+      deleteFunctionPromises.push(this.deleteFunction(functionName));
+    });
+
+    return BbPromise.all(deleteFunctionPromises);
+  }
+
+  deleteFunction(functionName) {
     const requestUrl = `https://${functionAppName}${constants.scmVfsPath}${functionName}/?recursive=true`;
     const options = {
       'host': functionAppName + constants.scmDomain,
@@ -580,7 +573,7 @@ return BbPromise.all(deleteFunctionPromises);
       }
     };
 
-return new BbPromise((resolve, reject) => {
+    return new BbPromise((resolve, reject) => {
       request(options, (err, res, body) => {
         if (err) {
           reject(err);
@@ -591,8 +584,8 @@ return new BbPromise((resolve, reject) => {
     });
   }
 
-  uploadPackageJson (functionName) {
-    const requestUrl = `https://${functionAppName}${constants.scmVfsPath}package.json`;
+  uploadPackageJson(functionName) {
+    const requestUrl = `https://${functionAppName}${constants.scmVfsPath}${functionName}/package.json`;
     const options = {
       'host': functionAppName + constants.scmDomain,
       'method': 'put',
@@ -605,19 +598,19 @@ return new BbPromise((resolve, reject) => {
     };
     var packageJsonFilePath = path.join(this.serverless.config.servicePath, 'package.json');
 
-return new BbPromise((resolve, reject) => {
+    return new BbPromise((resolve, reject) => {
       fs.createReadStream(packageJsonFilePath)
-            .pipe(request.put(options, (err, res, body) => {
-              if (err) {
-                reject(err);
-              } else {
-                resolve('Package json file uploaded');
-              }
-            }));
+        .pipe(request.put(options, (err, res, body) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve('Package json file uploaded');
+          }
+        }));
     });
   }
 
-  createZipObject (functionName, entryPoint, filePath, params) {
+  createZipObject(functionName, entryPoint, filePath, params) {
     return new BbPromise((resolve, reject) => {
       this.serverless.cli.log(`Packaging function: ${functionName}`);
       const folderForJSFunction = path.join(functionsFolder, functionName);
@@ -668,7 +661,7 @@ return new BbPromise((resolve, reject) => {
     });
   }
 
-  createZipFileAndUploadFunction (folder, zip) {
+  createZipFileAndUploadFunction(folder, zip) {
     return new BbPromise((resolve, reject) => {
       const generateOptions = {
         'type': 'nodebuffer',
@@ -705,14 +698,14 @@ return new BbPromise((resolve, reject) => {
     });
   }
 
-  createAndUploadZipFunctions () {
+  createAndUploadZipFunctions() {
     const zipFunctions = [];
 
     for (let j = 0; j < zipArray.length; j++) {
       zipFunctions.push(this.createZipFileAndUploadFunction(zipArray[j].key, zipArray[j].value));
     }
 
-return BbPromise.all(zipFunctions);
+    return BbPromise.all(zipFunctions);
   }
 }
 module.exports = AzureProvider;

--- a/provider/azureProvider.js
+++ b/provider/azureProvider.js
@@ -16,6 +16,7 @@ const parseBindings = require('../shared/parseBindings');
 let resourceGroupName;
 let deploymentName;
 let functionAppName;
+let hostingPlanName;
 let subscriptionId;
 let servicePrincipalTenantId;
 let servicePrincipalClientId;
@@ -72,15 +73,21 @@ class AzureProvider {
     servicePrincipalClientId = this.getSetting(azureCredentials.azureservicePrincipalClientId);
     servicePrincipalPassword = this.getSetting(azureCredentials.azureServicePrincipalPassword);
 
-    functionAppName = this.serverless.service.service;
 
+    functionAppName = this.serverless.service.service;
+    if(this.serverless.service.provider.functionAppName) {
+        functionAppName = this.serverless.service.provider.functionAppName;
+    }
+
+    hostingPlanName = this.serverless.service.service + '-hosting';
+    if(this.serverless.service.provider.hostingPlanName) {
+      hostingPlanName = this.serverless.service.provider.hostingPlanName;
+    }
+
+    resourceGroupName = `${functionAppName}-rg`;
     if (this.serverless.service.provider.resourceGroup) {
       this.isDefaultResourceGroup = false;
       resourceGroupName = this.serverless.service.provider.resourceGroup;
-    }
-    else {
-      this.isDefaultResourceGroup = true;
-      resourceGroupName = `${functionAppName}-rg`;
     }
 
     deploymentName = `${resourceGroupName}-deployment`;
@@ -152,6 +159,7 @@ class AzureProvider {
     if (gitUrl) {
       parameters = {
         'functionAppName': { 'value': functionAppName },
+        'hostingPlanName' : { 'value' : hostingPlanName},
         'gitUrl': { 'value': gitUrl }
       };
     }

--- a/provider/azureProvider.js
+++ b/provider/azureProvider.js
@@ -540,10 +540,16 @@ class AzureProvider {
 
     return new BbPromise((resolve, reject) => {
       request(options, (err, res, body) => {
+        this.serverless.cli.log(`Syncing Triggers....`);
         if (err) {
           reject(err);
         }
-        this.serverless.cli.log(`Syncing Triggers....Response statuscode: ${res.statusCode}`);
+
+        if(res.statusCode != 200) {
+        this.serverless.cli.log(`Syncing Triggers returned a non-200 status code. StatusCode: ${res.statusCode}  Body: ${res.body}`);
+
+        }
+        
         resolve(res);
       });
     });

--- a/remove/azureRemove.js
+++ b/remove/azureRemove.js
@@ -2,10 +2,11 @@
 
 const BbPromise = require('bluebird');
 const deleteResourceGroup = require('./lib/deleteResourceGroup');
+const cleanUpFunctions = require('./lib/cleanUpFunctions');
 const loginToAzure = require('../shared/loginToAzure');
 
 class AzureRemove {
-  constructor (serverless, options) {
+  constructor(serverless, options) {
     this.serverless = serverless;
     this.options = options;
     this.provider = this.serverless.getProvider('azure');
@@ -13,15 +14,30 @@ class AzureRemove {
     Object.assign(
       this,
       loginToAzure,
+      cleanUpFunctions,
       deleteResourceGroup
     );
 
-    this.hooks = {
-      'remove:remove': () => BbPromise.bind(this)
-        .then(this.loginToAzure)
-        .then(this.deleteResourceGroup)
-        .then(() => this.serverless.cli.log('Service successfully removed'))
-    };
+    // if we are using the default resource group (i.e. the developer hasn't specified one in the serverless.yml file)
+    // or the developer has provided the --clean command-line argument, then we will perform the remove by deleting everything
+    // from azure, leaving the subscription in a clean state.
+    if (options.clean || this.provider.isDefaultResourceGroup) {
+      this.hooks = {
+        'remove:remove': () => BbPromise.bind(this)
+          .then(this.loginToAzure)
+          .then(this.deleteResourceGroup)
+          .then(() => this.serverless.cli.log('Service successfully removed, Resource Group deleted.'))
+      };
+    }
+    else {
+      this.hooks = {
+        'remove:remove': () => BbPromise.bind(this)
+          .then(this.loginToAzure)
+          .then(this.cleanUpFunctions)
+          .then(() => this.serverless.cli.log('Service successfully removed'))
+          .then(() => this.serverless.cli.log(`\n\nNOTE: Only service functions have been removed. To remove the deployment provide '--clean' as a CLI argument.`))
+      };
+    }
   }
 }
 

--- a/remove/lib/cleanUpFunctions.js
+++ b/remove/lib/cleanUpFunctions.js
@@ -1,0 +1,9 @@
+'use strict';
+
+module.exports = {
+  cleanUpFunctions () {
+    return this.provider.isExistingFunctionApp()
+      .then(() => this.provider.getDeployedFunctionsNames())
+      .then(() => this.provider.deleteFunctions(this.serverless.service.getAllFunctions()));
+  }
+};

--- a/remove/lib/cleanUpFunctions.js
+++ b/remove/lib/cleanUpFunctions.js
@@ -1,7 +1,9 @@
 'use strict';
 
 module.exports = {
-  cleanUpFunctions () {
+  cleanUpFunctions() {
+    this.provider.initialise(this.serverless, this.options);
+
     return this.provider.isExistingFunctionApp()
       .then(() => this.provider.getDeployedFunctionsNames())
       .then(() => this.provider.deleteFunctions(this.serverless.service.getAllFunctions()));

--- a/remove/lib/deleteResourceGroup.js
+++ b/remove/lib/deleteResourceGroup.js
@@ -1,7 +1,9 @@
 'use strict';
 
 module.exports = {
-  deleteResourceGroup () {
+  deleteResourceGroup() {
+    this.provider.initialise(this.serverless, this.options);
+
     return this.provider.LoginWithServicePrincipal()
       .then(() => this.provider.DeleteDeployment())
       .then(() => this.provider.DeleteResourceGroup());

--- a/shared/getAdminKey.js
+++ b/shared/getAdminKey.js
@@ -2,6 +2,7 @@
 
 module.exports = {
   getAdminKey () {
+    this.provider.initialise(this.serverless, this.options);
     return this.provider.getAdminKey();
   }
 };

--- a/shared/loginToAzure.js
+++ b/shared/loginToAzure.js
@@ -3,7 +3,8 @@
 module.exports = {
   loginToAzure () {
     this.serverless.cli.log('Logging in to Azure');
+    this.provider.initialise(this.serverless, this.options);
 
-return this.provider.LoginWithServicePrincipal();
+    return this.provider.LoginWithServicePrincipal();
   }
 };


### PR DESCRIPTION
This pull request contains changes for:

#46 
- set the CLI options on the plugin manager to pass the options through to the plugins
- set a config property (`preserveDeployedFunctions`) if a `--preserve` command line argument is provided
- skip deleting the existing functions that are deployed to a host if the `preserveDeployedFunctions` is set

#44 
- allow the specification of a `resourceGroup` property under the provider node in `serverless.yml` file
- updated `AzureProvider` to check for this property and override the default name if it is set.