### PR TITLE
Fix for Issue #53

### DIFF
--- a/deploy/azureDeploy.js
+++ b/deploy/azureDeploy.js
@@ -22,12 +22,12 @@ class AzureDeploy {
 
     this.hooks = {
       'before:deploy:deploy': () => BbPromise.bind(this)
-        .then(this.provider.initialise(this.serverless,this.options))
+        .then(this.provider.initialize(this.serverless, this.options))
         .then(this.loginToAzure)
         .then(this.cleanUpFunctions),
 
       'deploy:deploy': () => BbPromise.bind(this)
-        .then(this.provider.initialise(this.serverless,this.options))
+        .then(this.provider.initialize(this.serverless,this.options))
         .then(this.CreateResourceGroupAndFunctionApp)
         .then(this.createFunctions)
         .then(() => this.serverless.cli.log('Successfully created Function App'))

--- a/deploy/azureDeploy.js
+++ b/deploy/azureDeploy.js
@@ -22,10 +22,12 @@ class AzureDeploy {
 
     this.hooks = {
       'before:deploy:deploy': () => BbPromise.bind(this)
+        .then(this.provider.initialise(this.serverless,this.options))
         .then(this.loginToAzure)
         .then(this.cleanUpFunctions),
 
       'deploy:deploy': () => BbPromise.bind(this)
+        .then(this.provider.initialise(this.serverless,this.options))
         .then(this.CreateResourceGroupAndFunctionApp)
         .then(this.createFunctions)
         .then(() => this.serverless.cli.log('Successfully created Function App'))

--- a/deploy/azureDeployFunction.js
+++ b/deploy/azureDeployFunction.js
@@ -18,6 +18,7 @@ class AzureDeployFunction {
 
     this.hooks = {
       'deploy:function:deploy': () => BbPromise.bind(this)
+        .then(this.provider.initialise(this.serverless,this.options))
         .then(this.loginToAzure)
         .then(this.createFunction)
         .then(() => this.serverless.cli.log('Successfully uploaded Function'))

--- a/deploy/azureDeployFunction.js
+++ b/deploy/azureDeployFunction.js
@@ -18,7 +18,7 @@ class AzureDeployFunction {
 
     this.hooks = {
       'deploy:function:deploy': () => BbPromise.bind(this)
-        .then(this.provider.initialise(this.serverless,this.options))
+        .then(this.provider.initialize(this.serverless,this.options))
         .then(this.loginToAzure)
         .then(this.createFunction)
         .then(() => this.serverless.cli.log('Successfully uploaded Function'))

--- a/index.js
+++ b/index.js
@@ -19,7 +19,8 @@ class AzureIndex {
     this.serverless = serverless;
     this.options = options;
 
-    this.serverless.pluginManager.addPlugin(AzureProvider);
+    this.serverless.setProvider(AzureProvider.getProviderName(), new AzureProvider(serverless));
+
     this.serverless.pluginManager.addPlugin(AzureDeploy);
     this.serverless.pluginManager.addPlugin(AzureDeployFunction);
     this.serverless.pluginManager.addPlugin(AzureInvoke);

--- a/invoke/azureInvoke.js
+++ b/invoke/azureInvoke.js
@@ -33,12 +33,12 @@ class AzureInvoke {
     this.hooks = {
 
       'before:invoke:invoke': () => BbPromise.bind(this)
-        .then(this.provider.initialise(this.serverless,this.options))
+        .then(this.provider.initialize(this.serverless,this.options))
         .then(this.loginToAzure)
         .then(this.getAdminKey),
 
       'invoke:invoke': () => BbPromise.bind(this)
-        .then(this.provider.initialise(this.serverless,this.options))
+        .then(this.provider.initialize(this.serverless,this.options))
         .then(this.invokeFunction)
     };
   }

--- a/invoke/azureInvoke.js
+++ b/invoke/azureInvoke.js
@@ -33,10 +33,12 @@ class AzureInvoke {
     this.hooks = {
 
       'before:invoke:invoke': () => BbPromise.bind(this)
+        .then(this.provider.initialise(this.serverless,this.options))
         .then(this.loginToAzure)
         .then(this.getAdminKey),
 
       'invoke:invoke': () => BbPromise.bind(this)
+        .then(this.provider.initialise(this.serverless,this.options))
         .then(this.invokeFunction)
     };
   }

--- a/logs/azureLogs.js
+++ b/logs/azureLogs.js
@@ -18,11 +18,11 @@ class AzureLogs {
 
     this.hooks = {
       'before:logs:logs': () => BbPromise.bind(this)
-        .then(this.provider.initialise(this.serverless,this.options))
+        .then(this.provider.initialize(this.serverless,this.options))
         .then(this.loginToAzure),
 
       'logs:logs': () => BbPromise.bind(this)
-        .then(this.provider.initialise(this.serverless,this.options))
+        .then(this.provider.initialize(this.serverless,this.options))
         .then(this.retrieveLogs)
     };
   }

--- a/logs/azureLogs.js
+++ b/logs/azureLogs.js
@@ -18,9 +18,11 @@ class AzureLogs {
 
     this.hooks = {
       'before:logs:logs': () => BbPromise.bind(this)
-      .then(this.loginToAzure),
+        .then(this.provider.initialise(this.serverless,this.options))
+        .then(this.loginToAzure),
 
       'logs:logs': () => BbPromise.bind(this)
+        .then(this.provider.initialise(this.serverless,this.options))
         .then(this.retrieveLogs)
     };
   }

--- a/provider/azureProvider.js
+++ b/provider/azureProvider.js
@@ -69,7 +69,7 @@ return constants.providerName;
     this.serverless.setProvider(constants.providerName, this);
   }
 
-  initialise(serverless, options) {
+  initialize(serverless, options) {
     this.serverless = serverless;
     this.options = options;
     

--- a/provider/azureProvider.js
+++ b/provider/azureProvider.js
@@ -63,9 +63,16 @@ return constants.providerName;
   }
 
   constructor (serverless) {
-    this.serverless = serverless;
     this.provider = this;
+    this.serverless = serverless;
+
     this.serverless.setProvider(constants.providerName, this);
+  }
+
+  initialise(serverless, options) {
+    this.serverless = serverless;
+    this.options = options;
+    
     subscriptionId = this.getSetting(azureCredentials.azureSubId);
     servicePrincipalTenantId = this.getSetting(azureCredentials.azureServicePrincipalTenantId);
     servicePrincipalClientId = this.getSetting(azureCredentials.azureservicePrincipalClientId);
@@ -75,6 +82,7 @@ return constants.providerName;
     resourceGroupName = `${functionAppName}-rg`;
     deploymentName = `${resourceGroupName}-deployment`;
     functionsFolder = path.join(this.serverless.config.servicePath, 'functions');
+    
   }
 
   getParsedBindings () {

--- a/remove/azureRemove.js
+++ b/remove/azureRemove.js
@@ -18,7 +18,7 @@ class AzureRemove {
 
     this.hooks = {
       'remove:remove': () => BbPromise.bind(this)
-        .then(this.provider.initialise(this.serverless,this.options))
+        .then(this.provider.initialize(this.serverless,this.options))
         .then(this.loginToAzure)
         .then(this.deleteResourceGroup)
         .then(() => this.serverless.cli.log('Service successfully removed'))

--- a/remove/azureRemove.js
+++ b/remove/azureRemove.js
@@ -18,6 +18,7 @@ class AzureRemove {
 
     this.hooks = {
       'remove:remove': () => BbPromise.bind(this)
+        .then(this.provider.initialise(this.serverless,this.options))
         .then(this.loginToAzure)
         .then(this.deleteResourceGroup)
         .then(() => this.serverless.cli.log('Service successfully removed'))


### PR DESCRIPTION
This is a fix for Issue #53 

The constructor for the AzureProvider performs initialisation of variables used later in the process, however this constructor is called before the Serverless framework has initialised all of the variables from the `serverless.yml` file.

This change moves the initialisation process to each command to perform as a first step.