### PR TITLE
Adding an interactive login experience

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,13 +21,14 @@
   ],
   "dependencies": {
     "async": "^2.1.2",
+    "az-login": "^0.1.4",
+    "azure-arm-resource": "1.6.1-preview",
     "bluebird": "^3.4.6",
     "chalk": "^1.1.3",
-    "lodash": "^4.16.6",
     "fs-extra": "^2.0.0",
-    "request": "2.79.0",
+    "lodash": "^4.16.6",
     "ms-rest-azure": "^1.15.4",
-    "azure-arm-resource": "1.6.1-preview",
+    "request": "2.79.0",
     "zip-folder": "1.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "async": "^2.1.2",
-    "az-login": "^0.1.5",
+    "az-login": "^0.1.6",
     "azure-arm-resource": "1.6.1-preview",
     "bluebird": "^3.4.6",
     "chalk": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "async": "^2.1.2",
-    "az-login": "^0.1.4",
+    "az-login": "^0.1.5",
     "azure-arm-resource": "1.6.1-preview",
     "bluebird": "^3.4.6",
     "chalk": "^1.1.3",

--- a/remove/lib/deleteResourceGroup.js
+++ b/remove/lib/deleteResourceGroup.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   deleteResourceGroup () {
-    return this.provider.LoginWithServicePrincipal()
+    return this.provider.Login()
       .then(() => this.provider.DeleteDeployment())
       .then(() => this.provider.DeleteResourceGroup());
   }

--- a/shared/loginToAzure.js
+++ b/shared/loginToAzure.js
@@ -4,6 +4,6 @@ module.exports = {
   loginToAzure () {
     this.serverless.cli.log('Logging in to Azure');
 
-return this.provider.LoginWithServicePrincipal();
+    return this.provider.Login();
   }
 };


### PR DESCRIPTION
This PR introduces an interactive login experience (using the `az-login` component I'm working on), that allows devs to deploy/manage their Azure functions, without needing to explicitly create a service principal and then set the four env vars. This results in a simpler, less error-prone getting started experience. Additionally, this PR results in more code being removed, then added, which is always nice :)

With this change, if those env vars are set, then they will continue to be used (although it also supports the same env vars as Terraform as well, for increased interop). However, if they aren't set, then the CLI will initiate an interactive login by launching the user's default browser to the device login page (`https://aka.ms/devicelogin`), and copying the device code to the clipboard. Once login has been successfully completed, it will create a service principal behind the scenes, and persist in to disk, so that subsequent commands will naturally pick it up.

<img width="888" alt="screen shot 2017-04-25 at 5 10 16 pm" src="https://cloud.githubusercontent.com/assets/116461/25412806/60cd5d28-29da-11e7-968e-6e567cf1c2c4.png">

As far as subscription selection goes, if the authenticated account only has a single subscription, it will simply select that one (preventing the user from needing to set a subscription ID env var). If there are multiple subscriptions, and the user is using the Azure CLI 2.0, it will look to see what their default subscription has been set to from there. If that doesn't exist, then it will fall back to prompting the user for the subscription they would like to use.

<img width="548" alt="screen shot 2017-04-25 at 5 33 07 pm" src="https://cloud.githubusercontent.com/assets/116461/25413233/a314f97c-29dd-11e7-919a-b261e667f173.png">

This way, both the authentication and subscription selection process can be entirely guided.