### PR TITLE
Adding an interactive login experience

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,129 +1,75 @@
-# Azure Functions Plugin 
+# Azure Functions Serverless Plugin 
 
 This plugin enables Azure Functions support within the Serverless Framework.
 
 ## Getting started
 
-### 1. Get a Serverless Service with Azure as the Provider
+### Pre-requisites
 
-1. Recommend using Node v6.5.0
-1. Install the serverless tooling - `npm i -g serverless`
-1. Create boilerplate (change `my-app` to whatever you'd prefer): `serverless install --url https://github.com/azure/boilerplate-azurefunctions --name my-app`
-1. `cd my-app`
-2. `npm install`
+1. Node.js v6.5.0+ *(this is the runtime version supported by Azure Functions)*
+2. Serverless CLI. You can run `npm i -g serverless` if you don't already have it.
+3. An Azure account. If you don't already have one, you can sign up for a [free trial](https://azure.microsoft.com/en-us/free/) that includes $200 of free credit.
 
-### 2. Set up credentials
+### Create a new Azure service
 
-We'll set up an Azure Subscription and our service principal. You can learn more in the [credentials doc]( https://www.serverless.com/framework/docs/providers/azure/guide/credentials).
+1. Create a new service using the standard Node.js template: `serverless create -t azure-nodejs --name <APP_NAME>`
+2. CD into the generated app directory *(`cd <APP_NAME>`)*
+3. Install the app's NPM dependencies, which includes this plugin *(`npm install`)*
+4. Update the `service` property in your `serverless.yml` file, to ensure it specifies a unique app name:
 
-1. Set up an Azure Subscription
-
-    Sign up for a free account @ [https://azure.com](https://azure.microsoft.com/en-us/services/functions/).
-
-    Azure comes with a [free trial](https://azure.microsoft.com/en-us/free/) that includes $200 of free credit. 
-
-
-2. . Get the Azure CLI
-
-    ```
-    npm i -g azure-cli
+    ```yml
+    service: my-azure-functions-app # Name of the Azure function App you want to create
     ```
 
-3. Login to Azure
+### Deploy, test, and remove your service
 
-    ```
-    azure login
-    ```
-
-    This will give you a code and prompt you to visit [aka.ms/devicelogin](https://aka.ms/devicelogin). Provide the code and then login with your Azure identity (this may happen automatically if you're already logged in). You'll then be able to access your account via the CLI.
-
-4. Get your subcription and tenant id
-
-    ```
-    azure account show
-    ```
-
-    Save the subcription and tenant id for later
-
-5. Create a service principal for a given `<name>` and `<password>` and add contributor role.
-
-    ```
-    azure ad sp create -n <name> -p <password>
-    ```
-
-    This should return an object which has the `servicePrincipalNames` property on it and an ObjectId. Save the Object Id and one of the names in the array and the password you provided for later. If you need to look up your service principal later, you can use `azure ad sp -c <name>` where `<name>` is the name provided originally. Note that the `<name>` you provided is not the name you'll provide later, it is a name in the `servicePrincipalNames` array.
-
-    Then grant the SP contributor access with the ObjectId
+1. Deploy your new service to Azure! The first time you do this, you will be asked to authenticate with your Azure account, so the `serverless` CLI can manage Functions on your behalf. Simply follow the provided instructions, and the deployment will continue as soon as the authentication process is completed.
 
     ```bash
-    azure role assignment create --objectId <objectIDFromCreateStep> -o Contributor
+    serverless deploy
     ```
 
-6. Set up environment variables
+    > Note: Once you've authenticated, a new Azure "service principal" will be created, and used for subsequent deployments. This prevents you from needing to manually login again. See [below](#advanced-authentication) if you'd prefer to use a custom service principal instead.
 
-     You need to set up environment variables for your subscription id, tenant id, service principal name, and password. 
+2. Invoke a function, in order to test that it works:
 
     ```bash
-    # bash
-    export azureSubId='<subscriptionId>'
-    export azureServicePrincipalTenantId='<tenantId>'
-    export azureServicePrincipalClientId='<servicePrincipalName>'
-    export azureServicePrincipalPassword='<password>'
+    serverless invoke -f hello
     ```
 
-    ```powershell
-    # PowerShell
-    $env:azureSubId='<subscriptionId>'
-    $env:azureServicePrincipalTenantId='<tenantId>'
-    $env:azureServicePrincipalClientId='<servicePrincipalName>'
-    $env:azureServicePrincipalPassword='<password>'
+3. View the output logs of your newly deployed function:
+
+    ```bash
+    serverless logs -f hello
     ```
 
+5. Remove the service as soon as you're done with it *(optional)*, to ensure you don't incur any unexpected Azure charges:
 
-### 3. Update the config in `serverless.yml`
+    ```bash
+    serverless remove
+    ```  
 
-Open up your `serverless.yml` file and update the following information:
+  6. Make any code changes, `deploy` again, view logs, etc. and provide us feedback on how to make the experience even better!
 
-```yml
-service: my-azure-functions-app # Name of the Azure function App you want to create
+### Advanced Authentication
+
+The getting started walkthrough illustrates the interactive login experience, which is recommended for most users. However, if you'd prefer to create an Azure ["service principal"](https://github.com/Azure/azure-sdk-for-node/blob/master/Documentation/Authentication.md#2-azure-cli) yourself, you can indicate that this plugin should use its credentials instead, by setting the following environment variables:
+
+**Bash**
+```bash
+export azureSubId='<subscriptionId>'
+export azureServicePrincipalTenantId='<tenantId>'
+export azureServicePrincipalClientId='<servicePrincipalName>'
+export azureServicePrincipalPassword='<password>'
 ```
 
-### 4. Deploy, test, and remove your service
-
-1. **Deploy a Service:**
-
-  Use this when you have made changes to your Functions or you simply want to deploy all changes within your Service at the same time.
-  ```bash
-  serverless deploy
-  ```
-
-2. **Deploy the Function:**
-
-  Use this to quickly upload and overwrite your Azure function, allowing you to develop faster.
-  ```bash
-  serverless deploy function -f httpjs
-  ```
-
-3. **Invoke the Function:**
-
-  Invokes an Azure Function on Azure
-  ```bash
-  serverless invoke --path httpQueryString.json -f httpjs
-  ```
-
-4. **Stream the Function Logs:**
-
-  Open up a separate tab in your console and stream all logs for a specific Function using this command.
-  ```bash
-  serverless logs -f httpjs -t
-  ```
-
-5. **Remove the Service: (optional)**
-
-  Removes all Functions and Resources from your Azure subscription.
-  ```bash
-  serverless remove
-  ```  
+**Powershell**
+```powershell
+$env:azureSubId='<subscriptionId>'
+$env:azureServicePrincipalTenantId='<tenantId>'
+$env:azureServicePrincipalClientId='<servicePrincipalName>'
+$env:azureServicePrincipalPassword='<password>'
+```
 
 ### Contributing
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This plugin enables Azure Functions support within the Serverless Framework.
 ### Pre-requisites
 
 1. Node.js v6.5.0+ *(this is the runtime version supported by Azure Functions)*
-2. Serverless CLI. You can run `npm i -g serverless` if you don't already have it.
+2. Serverless CLI `v1.9.0+`. You can run `npm i -g serverless` if you don't already have it.
 3. An Azure account. If you don't already have one, you can sign up for a [free trial](https://azure.microsoft.com/en-us/free/) that includes $200 of free credit.
 
 ### Create a new Azure service

--- a/README.md
+++ b/README.md
@@ -12,14 +12,9 @@ This plugin enables Azure Functions support within the Serverless Framework.
 
 ### Create a new Azure service
 
-1. Create a new service using the standard Node.js template: `serverless create -t azure-nodejs --name <APP_NAME>`
-2. CD into the generated app directory: `cd <APP_NAME>`
+1. Create a new service using the standard Node.js template, specifying a unique name for your app: `serverless create -t azure-nodejs -p <appName>`
+2. CD into the generated app directory: `cd <appName>`
 3. Install the app's NPM dependencies, which includes this plugin: `npm install`
-4. Update the `service` property in your `serverless.yml` file, to ensure it specifies a unique app name:
-
-    ```yml
-    service: my-azure-functions-app # Name of the Azure function App you want to create
-    ```
 
 ### Deploy, test, and diagnose your Azure service
 
@@ -37,13 +32,15 @@ This plugin enables Azure Functions support within the Serverless Framework.
     serverless invoke -f hello
     ```
 
-3. View the output logs of your newly deployed function:
+3. Stream the output logs for your function:
 
     ```bash
     serverless logs -f hello
     ```
  
 4. Make some code changes, `deploy` again, view logs, etc. and provide us feedback on how to make the experience even better!
+
+    > Note: If you're working on a single function, you can use the `serverless deploy function -f <function>` command instead of `serverless deploy`, which will simply deploy the specified function instead of the entire service.
 
 If at any point, you no longer need your service, you can run the following command to remove the Azure Functions that were created, and ensure you don't incur any unexpected charges:
 

--- a/README.md
+++ b/README.md
@@ -13,8 +13,8 @@ This plugin enables Azure Functions support within the Serverless Framework.
 ### Create a new Azure service
 
 1. Create a new service using the standard Node.js template: `serverless create -t azure-nodejs --name <APP_NAME>`
-2. CD into the generated app directory *(`cd <APP_NAME>`)*
-3. Install the app's NPM dependencies, which includes this plugin *(`npm install`)*
+2. CD into the generated app directory: `cd <APP_NAME>`
+3. Install the app's NPM dependencies, which includes this plugin: `npm install`
 4. Update the `service` property in your `serverless.yml` file, to ensure it specifies a unique app name:
 
     ```yml

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This plugin enables Azure Functions support within the Serverless Framework.
     service: my-azure-functions-app # Name of the Azure function App you want to create
     ```
 
-### Deploy, test, and remove your service
+### Deploy, test, and diagnose your Azure service
 
 1. Deploy your new service to Azure! The first time you do this, you will be asked to authenticate with your Azure account, so the `serverless` CLI can manage Functions on your behalf. Simply follow the provided instructions, and the deployment will continue as soon as the authentication process is completed.
 

--- a/README.md
+++ b/README.md
@@ -42,14 +42,14 @@ This plugin enables Azure Functions support within the Serverless Framework.
     ```bash
     serverless logs -f hello
     ```
+ 
+4. Make some code changes, `deploy` again, view logs, etc. and provide us feedback on how to make the experience even better!
 
-5. Remove the service as soon as you're done with it *(optional)*, to ensure you don't incur any unexpected Azure charges:
+If at any point, you no longer need your service, you can run the following command to remove the Azure Functions that were created, and ensure you don't incur any unexpected charges:
 
-    ```bash
-    serverless remove
-    ```  
-
-  6. Make any code changes, `deploy` again, view logs, etc. and provide us feedback on how to make the experience even better!
+```bash
+serverless remove
+``` 
 
 ### Advanced Authentication
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "async": "^2.1.2",
-    "az-login": "^0.1.6",
+    "az-login": "^0.1.7",
     "azure-arm-resource": "1.6.1-preview",
     "bluebird": "^3.4.6",
     "chalk": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -21,13 +21,14 @@
   ],
   "dependencies": {
     "async": "^2.1.2",
+    "az-login": "^0.1.4",
+    "azure-arm-resource": "1.6.1-preview",
     "bluebird": "^3.4.6",
     "chalk": "^1.1.3",
-    "lodash": "^4.16.6",
     "fs-extra": "^2.0.0",
-    "request": "2.79.0",
+    "lodash": "^4.16.6",
     "ms-rest-azure": "^1.15.4",
-    "azure-arm-resource": "1.6.1-preview",
+    "request": "2.79.0",
     "zip-folder": "1.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "async": "^2.1.2",
-    "az-login": "^0.1.5",
+    "az-login": "^0.1.6",
     "azure-arm-resource": "1.6.1-preview",
     "bluebird": "^3.4.6",
     "chalk": "^1.1.3",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   ],
   "dependencies": {
     "async": "^2.1.2",
-    "az-login": "^0.1.4",
+    "az-login": "^0.1.5",
     "azure-arm-resource": "1.6.1-preview",
     "bluebird": "^3.4.6",
     "chalk": "^1.1.3",

--- a/provider/azureProvider.js
+++ b/provider/azureProvider.js
@@ -17,9 +17,6 @@ let resourceGroupName;
 let deploymentName;
 let functionAppName;
 let subscriptionId;
-let servicePrincipalTenantId;
-let servicePrincipalClientId;
-let servicePrincipalPassword;
 let functionsAdminKey;
 let invocationId;
 let oldLogs = '';
@@ -67,20 +64,10 @@ return constants.providerName;
     this.options = options;
 
     return new BbPromise((resolve, reject) => {
-        subscriptionId = this.getSetting(azureCredentials.azureSubId);
-        servicePrincipalTenantId = this.getSetting(azureCredentials.azureServicePrincipalTenantId);
-        servicePrincipalClientId = this.getSetting(azureCredentials.azureservicePrincipalClientId);
-        servicePrincipalPassword = this.getSetting(azureCredentials.azureServicePrincipalPassword);
-
         functionAppName = this.serverless.service.service;
-
         resourceGroupName = `${functionAppName}-rg`;
         deploymentName = `${resourceGroupName}-deployment`;
         functionsFolder = path.join(this.serverless.config.servicePath, 'functions');
-
-        if (!servicePrincipalTenantId || !servicePrincipalClientId || !servicePrincipalPassword || !subscriptionId) {
-            reject(new Error('Azure credentials not provided'));
-        }
 
         resolve();
     });

--- a/provider/azureProvider.js
+++ b/provider/azureProvider.js
@@ -11,7 +11,7 @@ const zipFolder = require('zip-folder');
 const request = require('request');
 const dns = require('dns');
 const parseBindings = require('../shared/parseBindings');
-const { login } = require("az-login");
+const { login } = require('az-login');
 
 let resourceGroupName;
 let deploymentName;

--- a/provider/azureProvider.js
+++ b/provider/azureProvider.js
@@ -81,17 +81,6 @@ return constants.providerName;
 return this.parsedBindings;
   }
 
-  getSetting (key) {
-    // Loop through environment variables looking for the keys, case insentivie
-    for (var k in process.env) {
-      if (process.env.hasOwnProperty(k)) {
-        if (k.toLowerCase() === key.toLowerCase()) {
-      return process.env[k];
-        }
-      }
-    }
-  }
-
   Login() {
     return login({ interactiveLoginHandler: (code) => {
         this.serverless.cli.log(`Paste this code (copied to your clipboard) into the launched browser, and complete the authentication process: ${code}`);

--- a/remove/lib/deleteResourceGroup.js
+++ b/remove/lib/deleteResourceGroup.js
@@ -2,7 +2,7 @@
 
 module.exports = {
   deleteResourceGroup () {
-    return this.provider.LoginWithServicePrincipal()
+    return this.provider.Login()
       .then(() => this.provider.DeleteDeployment())
       .then(() => this.provider.DeleteResourceGroup());
   }

--- a/shared/loginToAzure.js
+++ b/shared/loginToAzure.js
@@ -4,6 +4,6 @@ module.exports = {
   loginToAzure () {
     this.serverless.cli.log('Logging in to Azure');
 
-return this.provider.LoginWithServicePrincipal();
+    return this.provider.Login();
   }
 };


### PR DESCRIPTION
This PR introduces an interactive login experience (using the `az-login` component I'm working on), that allows devs to deploy/manage their Azure functions, without needing to explicitly create a service principal and then set the four env vars. This results in a simpler, less error-prone getting started experience. Additionally, this PR results in more code being removed, then added, which is always nice :)

With this change, if those env vars are set, then they will continue to be used (although it also supports the same env vars as Terraform as well, for increased interop). However, if they aren't set, then the CLI will initiate an interactive login by launching the user's default browser to the device login page (`https://aka.ms/devicelogin`), and copying the device code to the clipboard. Once login has been successfully completed, it will create a service principal behind the scenes, and persist in to disk, so that subsequent commands will naturally pick it up.

<img width="888" alt="screen shot 2017-04-25 at 5 10 16 pm" src="https://cloud.githubusercontent.com/assets/116461/25412806/60cd5d28-29da-11e7-968e-6e567cf1c2c4.png">

As far as subscription selection goes, if the authenticated account only has a single subscription, it will simply select that one (preventing the user from needing to set a subscription ID env var). If there are multiple subscriptions, and the user is using the Azure CLI 2.0, it will look to see what their default subscription has been set to from there. If that doesn't exist, then it will fall back to prompting the user for the subscription they would like to use.

<img width="548" alt="screen shot 2017-04-25 at 5 33 07 pm" src="https://cloud.githubusercontent.com/assets/116461/25413233/a314f97c-29dd-11e7-919a-b261e667f173.png">

This way, both the authentication and subscription selection process can be entirely guided.