### PR TITLE
Adding App Insights support

### DIFF
--- a/provider/armTemplates/azuredeploy.json
+++ b/provider/armTemplates/azuredeploy.json
@@ -89,7 +89,7 @@
                         },
                         {
                             "name": "FUNCTIONS_EXTENSION_VERSION",
-                            "value": "beta"
+                            "value": "~1"
                         },
                         {
                             "name": "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING",

--- a/provider/armTemplates/azuredeploy.json
+++ b/provider/armTemplates/azuredeploy.json
@@ -25,10 +25,21 @@
     "variables": {
         "functionAppName": "[parameters('functionAppName')]",
         "hostingPlanName": "[parameters('functionAppName')]",
+        "insightsName": "[concat(parameters('functionAppName'), '-insights')]",
         "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'azfunctions')]",
         "storageAccountid": "[concat(resourceGroup().id,'/providers/','Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]"
     },
     "resources": [
+        {
+            "type": "microsoft.insights/components",
+            "kind": "Node.JS",
+            "name": "[variables('insightsName')]",
+            "apiVersion": "2014-04-01",
+            "location": "eastus",
+            "properties": {
+                "ApplicationId": "[variables('insightsName')]"
+            }
+        },
         {
             "type": "Microsoft.Storage/storageAccounts",
             "name": "[variables('storageAccountName')]",
@@ -57,12 +68,17 @@
             "kind": "functionapp",
             "dependsOn": [
                 "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]",
-                "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
+                "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]",
+                "[resourceId('Microsoft.insights/components', variables('insightsName'))]"
             ],
             "properties": {
                 "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]",
                 "siteConfig": {
                     "appSettings": [
+                        {
+                            "name": "APPINSIGHTS_INSTRUMENTATIONKEY",
+                            "value": "[reference(variables('insightsName')).InstrumentationKey]"
+                        },
                         {
                             "name": "AzureWebJobsDashboard",
                             "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storageAccountName'), ';AccountKey=', listKeys(variables('storageAccountid'),'2015-05-01-preview').key1)]"
@@ -72,16 +88,16 @@
                             "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storageAccountName'), ';AccountKey=', listKeys(variables('storageAccountid'),'2015-05-01-preview').key1)]"
                         },
                         {
+                            "name": "FUNCTIONS_EXTENSION_VERSION",
+                            "value": "beta"
+                        },
+                        {
                             "name": "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING",
                             "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storageAccountName'), ';AccountKey=', listKeys(variables('storageAccountid'),'2015-05-01-preview').key1)]"
                         },
                         {
                             "name": "WEBSITE_CONTENTSHARE",
                             "value": "[toLower(variables('functionAppName'))]"
-                        },
-                        {
-                            "name": "FUNCTIONS_EXTENSION_VERSION",
-                            "value": "~1"
                         },
                         {
                             "name": "WEBSITE_NODE_DEFAULT_VERSION",

--- a/provider/armTemplates/azuredeployWithGit.json
+++ b/provider/armTemplates/azuredeployWithGit.json
@@ -31,11 +31,22 @@
     "variables": {
         "functionAppName": "[parameters('functionAppName')]",
         "hostingPlanName": "[parameters('functionAppName')]",
+        "insightsName": "[concat(parameters('functionAppName'), '-insights')]",
         "storageAccountName": "[concat(uniquestring(resourceGroup().id), 'azfunctions')]",
         "storageAccountid": "[concat(resourceGroup().id,'/providers/','Microsoft.Storage/storageAccounts/', variables('storageAccountName'))]",
         "gitRepoUrl": "[parameters('gitUrl')]"
     },
     "resources": [
+        {
+            "type": "microsoft.insights/components",
+            "kind": "Node.JS",
+            "name": "[variables('insightsName')]",
+            "apiVersion": "2014-04-01",
+            "location": "eastus",
+            "properties": {
+                "ApplicationId": "[variables('insightsName')]"
+            }
+        },
         {
             "type": "Microsoft.Storage/storageAccounts",
             "name": "[variables('storageAccountName')]",
@@ -76,12 +87,17 @@
             "kind": "functionapp",
             "dependsOn": [
                 "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]",
-                "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]"
+                "[resourceId('Microsoft.Storage/storageAccounts', variables('storageAccountName'))]",
+                "[resourceId('Microsoft.insights/components', variables('insightsName'))]"
             ],
             "properties": {
                 "serverFarmId": "[resourceId('Microsoft.Web/serverfarms', variables('hostingPlanName'))]",
                 "siteConfig": {
                     "appSettings": [
+                        {
+                            "name": "APPINSIGHTS_INSTRUMENTATIONKEY",
+                            "value": "[reference(variables('insightsName')).InstrumentationKey]"
+                        },
                         {
                             "name": "AzureWebJobsDashboard",
                             "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storageAccountName'), ';AccountKey=', listKeys(variables('storageAccountid'),'2015-05-01-preview').key1)]"
@@ -91,16 +107,16 @@
                             "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storageAccountName'), ';AccountKey=', listKeys(variables('storageAccountid'),'2015-05-01-preview').key1)]"
                         },
                         {
+                            "name": "FUNCTIONS_EXTENSION_VERSION",
+                            "value": "beta"
+                        },
+                        {
                             "name": "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING",
                             "value": "[concat('DefaultEndpointsProtocol=https;AccountName=', variables('storageAccountName'), ';AccountKey=', listKeys(variables('storageAccountid'),'2015-05-01-preview').key1)]"
                         },
                         {
                             "name": "WEBSITE_CONTENTSHARE",
                             "value": "[toLower(variables('functionAppName'))]"
-                        },
-                        {
-                            "name": "FUNCTIONS_EXTENSION_VERSION",
-                            "value": "~1"
                         },
                         {
                             "name": "WEBSITE_NODE_DEFAULT_VERSION",

--- a/provider/armTemplates/azuredeployWithGit.json
+++ b/provider/armTemplates/azuredeployWithGit.json
@@ -108,7 +108,7 @@
                         },
                         {
                             "name": "FUNCTIONS_EXTENSION_VERSION",
-                            "value": "beta"
+                            "value": "~1"
                         },
                         {
                             "name": "WEBSITE_CONTENTAZUREFILECONNECTIONSTRING",

--- a/provider/azureProvider.js
+++ b/provider/azureProvider.js
@@ -163,7 +163,7 @@ return new BbPromise((resolve, reject) => {
     let templateFilePath = path.join(__dirname, 'armTemplates', 'azuredeploy.json');
 
     if (gitUrl) {
-      templateFilePath = path.join(__dirname, 'armTemplates', 'azuredeployWithGit.json');
+      templateFilePath = path.join(__dirname, 'armTemplates', '.json');
     }
     if (this.serverless.service.provider.armTemplate) {
       templateFilePath = path.join(this.serverless.config.servicePath, this.serverless.service.provider.armTemplate.file);

--- a/provider/azureProvider.js
+++ b/provider/azureProvider.js
@@ -163,7 +163,7 @@ return new BbPromise((resolve, reject) => {
     let templateFilePath = path.join(__dirname, 'armTemplates', 'azuredeploy.json');
 
     if (gitUrl) {
-      templateFilePath = path.join(__dirname, 'armTemplates', '.json');
+      templateFilePath = path.join(__dirname, 'armTemplates', 'azuredeployWithGit.json');
     }
     if (this.serverless.service.provider.armTemplate) {
       templateFilePath = path.join(this.serverless.config.servicePath, this.serverless.service.provider.armTemplate.file);


### PR DESCRIPTION
This PR updates the existing ARM deployment templates, to create an App Insights instance, and bind the functions to it. This way, devs can deploy their functions, invoke them, etc. and then begin to monitor them without needing to do anything extra to set this up. Since App Insights provides a pretty permissive free-tier (1 GB data/month), it seems reasonable to create this resource by default.

Some questions to discuss around the design of this feature:

- [ ] Do we want to allow easily disabling provisioning an AI instance, or is it acceptable for now to just auto-create it? The user always has the option to provide a custom ARM template as a fallback, though that may be a little heavy-handed for this scenario.

- [x] Is it safe to always enable the beta runtime, or do we need to toggle this conditionally?

- [ ] AI is only available in four regions currently, so we can't reliably align the AI location with the specified region in the `serverless.yml` file. Is it sufficient for now to just lock it to `eastus`? Since this feature is trying to be a transparent value add, I'd hate to error out if a user tried to deploy a function that West US, and the AI instance couldn't be assigned to that location (for example).
