### PR TITLE
Fix typo in console output when uploading package.json

### DIFF
--- a/provider/azureProvider.js
+++ b/provider/azureProvider.js
@@ -537,7 +537,7 @@ class AzureProvider {
 
   uploadPackageJson () {
     const packageJsonFilePath = path.join(this.serverless.config.servicePath, 'package.json');
-    this.serverless.cli.log('Uploading pacakge.json...');
+    this.serverless.cli.log('Uploading package.json...');
     const requestUrl = `https://${functionAppName}${config.scmVfsPath}package.json`;
     const options = {
       host: functionAppName + config.scmDomain,


### PR DESCRIPTION
Was: `Serverless: Uploading pacakge.json...`
Now: `Serverless: Uploading package.json...`