### PR TITLE
Update provider to allow configuring resource group

### DIFF
--- a/provider/azureProvider.js
+++ b/provider/azureProvider.js
@@ -42,8 +42,8 @@ class AzureProvider {
 
     return new BbPromise((resolve) => {
       functionAppName = this.serverless.service.service;
-      resourceGroupName = `${functionAppName}-rg`;
-      deploymentName = `${resourceGroupName}-deployment`;
+      resourceGroupName = this.serverless.service.provider.resourceGroup || `${functionAppName}-rg`;
+      deploymentName = this.serverless.service.provider.deploymentName || `${resourceGroupName}-deployment`;
 
       resolve();
     });


### PR DESCRIPTION
This PR addresses #44 and #106 by allowing you to configure `resourceGroup` and 
`deploymentName` in `serverless.yml`.

```
provider:
  name: azure
  resourceGroup: your-resource-group
  deploymentName: your-deployment-name
```

We have been using this fork in production for several weeks with no issues.
