### PR TITLE
[WIP] feature: bump default node version to 8.16.0

### DIFF
--- a/src/provider/armTemplates/azuredeploy.json
+++ b/src/provider/armTemplates/azuredeploy.json
@@ -102,7 +102,7 @@
                         },
                         {
                             "name": "WEBSITE_NODE_DEFAULT_VERSION",
-                            "value": "8.11.1"
+                            "value": "8.16.0"
                         },
                         {
                             "name": "WEBSITE_RUN_FROM_PACKAGE",


### PR DESCRIPTION
# BLOCKER

Node `8.16.0` require `npm 6.4.1` but azure function web job
only support `npm 5.6.0`

- when deploy with `node 8.16.0` by setting `WEBSITE_NODE_DEFAULT_VERSION`, npm and node is messed up
<img width="496" alt="Screen Shot 2019-05-24 at 1 15 57 PM" src="https://user-images.githubusercontent.com/1634185/58354824-57994e80-7e27-11e9-8868-23a1da238174.png">


- function app won't work and there will be an error popup on the portal
<img width="350" alt="Screen Shot 2019-05-24 at 1 15 38 PM" src="https://user-images.githubusercontent.com/1634185/58354826-5b2cd580-7e27-11e9-9ca4-39547d3e7f33.png">

## Available node releases:
https://nodejs.org/en/download/releases/