### PR TITLE
fix: Ensures the correct SCM domain is found for uploading zip package

### DIFF
--- a/src/armTemplates/resources/appInsights.ts
+++ b/src/armTemplates/resources/appInsights.ts
@@ -1,5 +1,5 @@
 import { ArmResourceTemplateGenerator, ArmResourceTemplate } from "../../models/armTemplates";
-import { ServerlessAzureConfig, ResourceConfig } from "../../models/serverless";
+import { ServerlessAzureConfig } from "../../models/serverless";
 
 export class AppInsightsResource implements ArmResourceTemplateGenerator {
   public static getResourceName(config: ServerlessAzureConfig) {

--- a/src/armTemplates/resources/hostingEnvironment.ts
+++ b/src/armTemplates/resources/hostingEnvironment.ts
@@ -1,5 +1,5 @@
 import { ArmResourceTemplateGenerator, ArmResourceTemplate } from "../../models/armTemplates";
-import { ServerlessAzureConfig, ResourceConfig } from "../../models/serverless";
+import { ServerlessAzureConfig } from "../../models/serverless";
 
 export class HostingEnvironmentResource implements ArmResourceTemplateGenerator {
   public static getResourceName(config: ServerlessAzureConfig) {

--- a/src/armTemplates/resources/virtualNetwork.ts
+++ b/src/armTemplates/resources/virtualNetwork.ts
@@ -1,5 +1,5 @@
 import { ArmResourceTemplateGenerator, ArmResourceTemplate } from "../../models/armTemplates";
-import { ServerlessAzureConfig, ResourceConfig } from "../../models/serverless";
+import { ServerlessAzureConfig } from "../../models/serverless";
 
 export class VirtualNetworkResource implements ArmResourceTemplateGenerator {
   public static getResourceName(config: ServerlessAzureConfig) {

--- a/src/services/functionAppService.ts
+++ b/src/services/functionAppService.ts
@@ -241,7 +241,7 @@ export class FunctionAppService extends BaseService {
    */
   private getScmDomain(functionApp: Site) {
     return functionApp.enabledHostNames.find((hostName: string) => {
-      return hostName.endsWith("scm.azurewebsites.net");
+      return hostName.includes(".scm.") && hostName.endsWith(".azurewebsites.net");
     });
   }
 }


### PR DESCRIPTION
The SCM domain is different based on the type of function app deployment.  In a typical function app, the SCM domain is always {appName}.scm.azurewebsites.net.

When deploying a function into an App Service Environment (ASE) the SCM domain is a sub domain off of the ASE, ex) {appName}.scm.{asePath}.p.azurewebsites.net

This fix addresses the difference in finding the correct SCM domain to deploy the zip package.