### PR TITLE
fix: Simple fix in test of equality comparison

### DIFF
--- a/src/services/functionAppService.test.ts
+++ b/src/services/functionAppService.test.ts
@@ -107,8 +107,8 @@ describe("Function App Service", () => {
 
   it("gets master key", async () => {
     const service = createService();
-    const masterKey = await service.getMasterKey();
-    expect(masterKey).toEqual(masterKey);
+    const result = await service.getMasterKey();
+    expect(result).toEqual(masterKey);
 
   });
 


### PR DESCRIPTION
Discovered this small bug in the test. Overloading the variable name `masterKey`, using `result` instead.