### PR TITLE
fix: Remove await statement from Promise.all

### DIFF
--- a/src/services/functionAppService.ts
+++ b/src/services/functionAppService.ts
@@ -117,7 +117,7 @@ export class FunctionAppService extends BaseService {
 
     const functionZipFile = this.getFunctionZipFile();
     const uploadFunctionApp = this.uploadZippedArfifactToFunctionApp(functionApp, functionZipFile);
-    const uploadBlobStorage = await this.uploadZippedArtifactToBlobStorage(functionZipFile);
+    const uploadBlobStorage = this.uploadZippedArtifactToBlobStorage(functionZipFile);
     await Promise.all([uploadFunctionApp, uploadBlobStorage]);
   }
 


### PR DESCRIPTION
Remove forgotten `await` statement before using `Promise.all`