### PR TITLE
feat: Added feature to specify Azure subcription ID in CLI before deployment 

### DIFF
--- a/src/plugins/deploy/azureDeployPlugin.ts
+++ b/src/plugins/deploy/azureDeployPlugin.ts
@@ -3,12 +3,13 @@ import { FunctionAppService } from "../../services/functionAppService";
 import { ResourceService } from "../../services/resourceService";
 import { Utils } from "../../shared/utils";
 import { AzureBasePlugin } from "../azureBasePlugin";
+import { AzureLoginOptions } from "../../services/loginService";
 
 export class AzureDeployPlugin extends AzureBasePlugin {
   public hooks: { [eventName: string]: Promise<any> };
   public commands: any;
 
-  public constructor(serverless: Serverless, private options: Serverless.Options) {
+  public constructor(serverless: Serverless, private options: Serverless.Options & AzureLoginOptions) {
     super(serverless);
 
     this.hooks = {
@@ -30,6 +31,10 @@ export class AzureDeployPlugin extends AzureBasePlugin {
           "resourceGroup": {
             usage: "Resource group for the service",
             shortcut: "g",
+          }, 
+          subscriptionId: {
+            usage: "Sets the Azure subscription ID",
+            shortcut: "i",
           }
         }
       }
@@ -62,7 +67,6 @@ export class AzureDeployPlugin extends AzureBasePlugin {
 
   private async deploy() {
     const resourceService = new ResourceService(this.serverless, this.options);
-
     await resourceService.deployResourceGroup();
 
     const functionAppService = new FunctionAppService(this.serverless, this.options);

--- a/src/plugins/login/azureLoginPlugin.ts
+++ b/src/plugins/login/azureLoginPlugin.ts
@@ -1,13 +1,13 @@
 import Serverless from "serverless";
 import AzureProvider from "../../provider/azureProvider";
-import { AzureLoginService } from "../../services/loginService";
+import { AzureLoginService, AzureLoginOptions } from "../../services/loginService";
 import { AzureBasePlugin } from "../azureBasePlugin";
 
 export class AzureLoginPlugin extends AzureBasePlugin {
   private provider: AzureProvider;
   public hooks: { [eventName: string]: Promise<any> };
 
-  public constructor(serverless: Serverless, private options: Serverless.Options) {
+  public constructor(serverless: Serverless, private options: Serverless.Options & AzureLoginOptions) {
     super(serverless);
     this.provider = (this.serverless.getProvider("azure") as any) as AzureProvider;
 
@@ -32,7 +32,9 @@ export class AzureLoginPlugin extends AzureBasePlugin {
       this.serverless.variables["azureCredentials"] = authResult.credentials;
       // Use environment variable for sub ID or use the first subscription in the list (service principal can
       // have access to more than one subscription)
-      this.serverless.variables["subscriptionId"] = process.env.azureSubId || authResult.subscriptions[0].id;
+      this.serverless.variables["subscriptionId"] = this.options.subscriptionId || process.env.azureSubId || authResult.subscriptions[0].id;
+      this.serverless.cli.log(`Deploying with subscription ID: ${ this.serverless.variables["subscriptionId"]}`);
+
     }
     catch (e) {
       this.log("Error logging into azure");

--- a/src/services/loginService.ts
+++ b/src/services/loginService.ts
@@ -9,10 +9,6 @@ import {
 
 export interface AzureLoginOptions {
   subscriptionId?: string;
-  clientId?: string;
-  tenantId?: string;
-  password?: string;
-  interactive?: boolean;
 }
 
 export class AzureLoginService {

--- a/src/services/loginService.ts
+++ b/src/services/loginService.ts
@@ -7,6 +7,14 @@ import {
   InteractiveLoginOptions,  
 } from "@azure/ms-rest-nodeauth";
 
+export interface AzureLoginOptions {
+  subscriptionId?: string;
+  clientId?: string;
+  tenantId?: string;
+  password?: string;
+  interactive?: boolean;
+}
+
 export class AzureLoginService {
 
   /**


### PR DESCRIPTION
Added feature to specify subscription ID in the CLI which overrides any existing subscriptions ID and deploys the functions to the subscription specified by the user. 

```bash 
sls deploy -i <subscriptionID>
```
AB#360