### PR TITLE
feat: Added feature to specify Azure subcription ID in CLI before deployment

### DIFF
--- a/src/plugins/azureBasePlugin.ts
+++ b/src/plugins/azureBasePlugin.ts
@@ -5,7 +5,7 @@ import { Utils } from "../shared/utils";
 export abstract class AzureBasePlugin {
   public constructor(
     protected serverless: Serverless,
-    protected options: Serverless.Options,
+    protected options: Serverless.Options & Serverless.AzureLoginOptions,
   ) {
     Guard.null(serverless);
   }

--- a/src/plugins/azureBasePlugin.ts
+++ b/src/plugins/azureBasePlugin.ts
@@ -1,12 +1,11 @@
 import { Guard } from "../shared/guard";
 import Serverless from "serverless";
 import { Utils } from "../shared/utils";
-import { AzureLoginOptions } from "../services/loginService";
 
-export abstract class AzureBasePlugin {
+export abstract class AzureBasePlugin<TOptions=Serverless.Options> {
   public constructor(
     protected serverless: Serverless,
-    protected options: Serverless.Options & AzureLoginOptions,
+    protected options: TOptions,
   ) {
     Guard.null(serverless);
   }

--- a/src/plugins/azureBasePlugin.ts
+++ b/src/plugins/azureBasePlugin.ts
@@ -1,11 +1,12 @@
 import { Guard } from "../shared/guard";
 import Serverless from "serverless";
 import { Utils } from "../shared/utils";
+import { AzureLoginOptions } from "../services/loginService";
 
 export abstract class AzureBasePlugin {
   public constructor(
     protected serverless: Serverless,
-    protected options: Serverless.Options & Serverless.AzureLoginOptions,
+    protected options: Serverless.Options & AzureLoginOptions,
   ) {
     Guard.null(serverless);
   }

--- a/src/plugins/deploy/azureDeployPlugin.ts
+++ b/src/plugins/deploy/azureDeployPlugin.ts
@@ -9,7 +9,7 @@ export class AzureDeployPlugin extends AzureBasePlugin {
   public hooks: { [eventName: string]: Promise<any> };
   public commands: any;
 
-  public constructor(serverless: Serverless, options: Serverless.Options) {
+  public constructor(serverless: Serverless, options: Serverless.Options & Serverless.AzureLoginOptions) {
     super(serverless, options);
 
     this.hooks = {
@@ -31,6 +31,10 @@ export class AzureDeployPlugin extends AzureBasePlugin {
           "resourceGroup": {
             usage: "Resource group for the service",
             shortcut: "g",
+          },
+          subscriptionId: {
+            usage: "Sets the Azure subscription ID",
+            shortcut: "i",
           }
         }
       }

--- a/src/plugins/deploy/azureDeployPlugin.ts
+++ b/src/plugins/deploy/azureDeployPlugin.ts
@@ -3,13 +3,13 @@ import { FunctionAppService } from "../../services/functionAppService";
 import { ResourceService } from "../../services/resourceService";
 import { Utils } from "../../shared/utils";
 import { AzureBasePlugin } from "../azureBasePlugin";
-
+import { AzureLoginOptions } from "../../services/loginService";
 
 export class AzureDeployPlugin extends AzureBasePlugin {
   public hooks: { [eventName: string]: Promise<any> };
   public commands: any;
 
-  public constructor(serverless: Serverless, options: Serverless.Options & Serverless.AzureLoginOptions) {
+  public constructor(serverless: Serverless, options: Serverless.Options & AzureLoginOptions) {
     super(serverless, options);
 
     this.hooks = {

--- a/src/plugins/deploy/azureDeployPlugin.ts
+++ b/src/plugins/deploy/azureDeployPlugin.ts
@@ -5,11 +5,11 @@ import { Utils } from "../../shared/utils";
 import { AzureBasePlugin } from "../azureBasePlugin";
 import { AzureLoginOptions } from "../../services/loginService";
 
-export class AzureDeployPlugin extends AzureBasePlugin {
+export class AzureDeployPlugin extends AzureBasePlugin<AzureLoginOptions> {
   public hooks: { [eventName: string]: Promise<any> };
   public commands: any;
 
-  public constructor(serverless: Serverless, options: Serverless.Options & AzureLoginOptions) {
+  public constructor(serverless: Serverless, options: AzureLoginOptions) {
     super(serverless, options);
 
     this.hooks = {

--- a/src/plugins/login/azureLoginPlugin.test.ts
+++ b/src/plugins/login/azureLoginPlugin.test.ts
@@ -15,8 +15,7 @@ describe("Login Plugin", () => {
     if (!hasCreds) {
       delete sls.variables["azureCredentials"];
     }
-    const opt = options || MockFactory.createTestServerlessOptions();
-    return new AzureLoginPlugin(sls, opt);
+    return new AzureLoginPlugin(sls, options || MockFactory.createTestServerlessOptions());
   }
 
   function createMockLoginFunction() {
@@ -103,13 +102,12 @@ describe("Login Plugin", () => {
     expect(sls.cli.log).toBeCalledWith("Using subscription ID: test-subs-id");
   })
 
-  it(" Uses the default subscription ID" , async () => {
+  it("Uses the default subscription ID" , async () => {
     const sls = MockFactory.createTestServerless();
     const opt = MockFactory.createTestServerlessOptions();
     await invokeLoginHook(false, sls, opt);
     expect(AzureLoginService.interactiveLogin).toBeCalled()
     expect(sls.variables["subscriptionId"]).toEqual("azureSubId");
     expect(sls.cli.log).toBeCalledWith("Using subscription ID: azureSubId");
-  })
-
+  });
 });

--- a/src/plugins/login/azureLoginPlugin.ts
+++ b/src/plugins/login/azureLoginPlugin.ts
@@ -7,7 +7,7 @@ export class AzureLoginPlugin extends AzureBasePlugin {
   private provider: AzureProvider;
   public hooks: { [eventName: string]: Promise<any> };
 
-  public constructor(serverless: Serverless, options: Serverless.Options) {
+  public constructor(serverless: Serverless, options: Serverless.Options & Serverless.AzureLoginOptions) {
     super(serverless, options);
     this.provider = (this.serverless.getProvider("azure") as any) as AzureProvider;
 
@@ -32,7 +32,8 @@ export class AzureLoginPlugin extends AzureBasePlugin {
       this.serverless.variables["azureCredentials"] = authResult.credentials;
       // Use environment variable for sub ID or use the first subscription in the list (service principal can
       // have access to more than one subscription)
-      this.serverless.variables["subscriptionId"] = process.env.azureSubId || authResult.subscriptions[0].id;
+      this.serverless.variables["subscriptionId"] = this.options.subscriptionId || process.env.azureSubId || authResult.subscriptions[0].id;
+      this.serverless.cli.log(`Using subscription ID: ${this.serverless.variables["subscriptionId"]}`);
     }
     catch (e) {
       this.log("Error logging into azure");

--- a/src/plugins/login/azureLoginPlugin.ts
+++ b/src/plugins/login/azureLoginPlugin.ts
@@ -2,12 +2,13 @@ import Serverless from "serverless";
 import AzureProvider from "../../provider/azureProvider";
 import { AzureLoginService } from "../../services/loginService";
 import { AzureBasePlugin } from "../azureBasePlugin";
+import { AzureLoginOptions } from "../../services/loginService";
 
 export class AzureLoginPlugin extends AzureBasePlugin {
   private provider: AzureProvider;
   public hooks: { [eventName: string]: Promise<any> };
 
-  public constructor(serverless: Serverless, options: Serverless.Options & Serverless.AzureLoginOptions) {
+  public constructor(serverless: Serverless, options: Serverless.Options & AzureLoginOptions) {
     super(serverless, options);
     this.provider = (this.serverless.getProvider("azure") as any) as AzureProvider;
 

--- a/src/plugins/login/azureLoginPlugin.ts
+++ b/src/plugins/login/azureLoginPlugin.ts
@@ -4,11 +4,11 @@ import { AzureLoginService } from "../../services/loginService";
 import { AzureBasePlugin } from "../azureBasePlugin";
 import { AzureLoginOptions } from "../../services/loginService";
 
-export class AzureLoginPlugin extends AzureBasePlugin {
+export class AzureLoginPlugin extends AzureBasePlugin<AzureLoginOptions> {
   private provider: AzureProvider;
   public hooks: { [eventName: string]: Promise<any> };
 
-  public constructor(serverless: Serverless, options: Serverless.Options & AzureLoginOptions) {
+  public constructor(serverless: Serverless, options: AzureLoginOptions) {
     super(serverless, options);
     this.provider = (this.serverless.getProvider("azure") as any) as AzureProvider;
 

--- a/src/services/loginService.ts
+++ b/src/services/loginService.ts
@@ -7,6 +7,7 @@ import {
   InteractiveLoginOptions,  
 } from "@azure/ms-rest-nodeauth";
 
+
 export class AzureLoginService {
 
   /**

--- a/src/services/loginService.ts
+++ b/src/services/loginService.ts
@@ -7,6 +7,9 @@ import {
   InteractiveLoginOptions,  
 } from "@azure/ms-rest-nodeauth";
 
+export interface AzureLoginOptions {
+  subscriptionId?: string;
+}
 
 export class AzureLoginService {
 

--- a/src/services/loginService.ts
+++ b/src/services/loginService.ts
@@ -1,4 +1,5 @@
 import open from "open";
+import Serverless from "serverless";
 import {
   interactiveLoginWithAuthResponse,
   loginWithServicePrincipalSecretWithAuthResponse,
@@ -7,7 +8,7 @@ import {
   InteractiveLoginOptions,  
 } from "@azure/ms-rest-nodeauth";
 
-export interface AzureLoginOptions {
+export interface AzureLoginOptions extends Serverless.Options {
   subscriptionId?: string;
 }
 


### PR DESCRIPTION
Added feature to specify subscription ID in the CLI which overrides any existing subscriptions ID and deploys the functions to the subscription specified by the user.

```bash
sls deploy -i <subscriptionID>
```

AB#360