### PR TITLE
refactor: Moved hooks requiring login to separate file

### DIFF
--- a/src/plugins/login/azureLoginPlugin.test.ts
+++ b/src/plugins/login/azureLoginPlugin.test.ts
@@ -3,6 +3,7 @@ import { AzureLoginService } from "../../services/loginService";
 import { MockFactory } from "../../test/mockFactory";
 import { invokeHook, setEnvVariables, unsetEnvVariables } from "../../test/utils";
 import { AzureLoginPlugin } from "./azureLoginPlugin";
+import { loginHooks } from "./loginHooks";
 
 describe("Login Plugin", () => {
 
@@ -32,12 +33,16 @@ describe("Login Plugin", () => {
 
   async function invokeLoginHook(hasCreds = false, serverless?: Serverless, options?: Serverless.Options) {
     const plugin = createPlugin(hasCreds, serverless, options);
-    await invokeHook(plugin, "before:deploy:deploy");
+    await invokeHook(plugin, `before:${loginHooks[0]}`);
   }
 
   beforeEach(() => {
     AzureLoginService.interactiveLogin = createMockLoginFunction();
     AzureLoginService.servicePrincipalLogin = createMockLoginFunction();
+  });
+
+  it("contains the hooks as contained in loginHooks", () => {
+    expect(Object.keys(createPlugin().hooks)).toEqual(loginHooks.map((hook) => `before:${hook}`));
   });
 
   it("returns if azure credentials are set", async () => {

--- a/src/plugins/login/azureLoginPlugin.ts
+++ b/src/plugins/login/azureLoginPlugin.ts
@@ -1,23 +1,18 @@
 import Serverless from "serverless";
-import AzureProvider from "../../provider/azureProvider";
-import { AzureLoginService } from "../../services/loginService";
+import { AzureLoginOptions, AzureLoginService } from "../../services/loginService";
 import { AzureBasePlugin } from "../azureBasePlugin";
-import { AzureLoginOptions } from "../../services/loginService";
+import { loginHooks } from "./loginHooks";
 
 export class AzureLoginPlugin extends AzureBasePlugin<AzureLoginOptions> {
-  private provider: AzureProvider;
   public hooks: { [eventName: string]: Promise<any> };
 
   public constructor(serverless: Serverless, options: AzureLoginOptions) {
     super(serverless, options);
-    this.provider = (this.serverless.getProvider("azure") as any) as AzureProvider;
 
-    this.hooks = {
-      "before:deploy:deploy": this.login.bind(this),
-      "before:deploy:list:list": this.login.bind(this),
-      "before:invoke:invoke": this.login.bind(this),
-      "before:rollback:rollback": this.login.bind(this),
-    };
+    this.hooks = {};
+    for (const h of loginHooks) {
+      this.hooks[`before:${h}`] = this.login.bind(this);
+    }
   }
 
   private async login() {

--- a/src/plugins/login/loginHooks.ts
+++ b/src/plugins/login/loginHooks.ts
@@ -1,0 +1,11 @@
+/**
+ * Hooks that require authentication before execution
+ */
+export const loginHooks = [
+  "package:initialize",
+  "deploy:list:list",
+  "deploy:deploy",
+  "invoke:invoke",
+  "rollback:rollback",
+  "remove:remove",
+]


### PR DESCRIPTION
 Rather than changing the `AzureLoginPlugin` to add `"before:new:hook": this.login.bind(this)` every time a new hook is added that needs authentication, this allows for the hooks (without `before:`) to be placed in a separate file. These are loaded in the constructor of the plugin, which sets up the proper hooks.