### PR TITLE
fix: apim uses shortened region names

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-azure-functions",
-  "version": "1.0.0-6",
+  "version": "1.0.0-7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-azure-functions",
-  "version": "1.0.0-6",
+  "version": "1.0.0-7",
   "description": "Provider plugin for the Serverless Framework v1.x which adds support for Azure Functions.",
   "license": "MIT",
   "main": "./lib/index.js",

--- a/src/services/apimService.test.ts
+++ b/src/services/apimService.test.ts
@@ -19,6 +19,7 @@ import {
   OperationContract,
   ApiPolicyCreateOrUpdateResponse,
 } from "@azure/arm-apimanagement/esm/models";
+import { Utils } from "../shared/utils";
 
 describe("APIM Service", () => {
   const apimConfig = MockFactory.createTestApimConfig();
@@ -46,7 +47,6 @@ describe("APIM Service", () => {
       subscriptionId: "ABC123",
     };
   });
-
   it("is defined", () => {
     expect(ApimService).toBeDefined();
   });
@@ -54,6 +54,16 @@ describe("APIM Service", () => {
   it("can be instantiated", () => {
     const service = new ApimService(serverless);
     expect(service).not.toBeNull();
+  });
+
+  it("when generated, has a shorted region name in the resource name", () => {
+    // if APIM name is ommited, it should auto-generate one that contains a shortened region name
+    const apimConfigName = MockFactory.createTestApimConfig(true);
+    (serverless.service.provider as any).apim = apimConfigName;
+
+    const service = new ApimService(serverless);
+    const expectedRegionName = Utils.createShortAzureRegionName(service.getRegion());
+    expect(apimConfigName.name.includes(expectedRegionName)).toBeTruthy();
   });
 
   describe("Get service reference", () => {

--- a/src/services/apimService.ts
+++ b/src/services/apimService.ts
@@ -10,6 +10,7 @@ import {
 } from "@azure/arm-apimanagement/esm/models";
 import { Site } from "@azure/arm-appservice/esm/models";
 import { Guard } from "../shared/guard";
+import { ApimResource } from "../armTemplates/resources/apim";
 
 /**
  * APIM Service handles deployment and integration with Azure API Management
@@ -28,7 +29,7 @@ export class ApimService extends BaseService {
     }
 
     if (!this.apimConfig.name) {
-      this.apimConfig.name = `${this.config.provider.prefix}-${this.config.provider.region}-${this.config.provider.stage}-apim`
+      this.apimConfig.name = ApimResource.getResourceName(this.config);
     }
 
     if (!this.apimConfig.backend) {

--- a/src/test/mockFactory.ts
+++ b/src/test/mockFactory.ts
@@ -267,9 +267,9 @@ export class MockFactory {
     return (asYaml) ? yaml.dump(data) : data;
   }
 
-  public static createTestApimConfig(): ApiManagementConfig {
+  public static createTestApimConfig(generateName: boolean = false): ApiManagementConfig {
     return {
-      name: "test-apim-resource",
+      name: generateName ? null : "test-apim-resource",
       api: {
         name: "test-apim-api1",
         subscriptionRequired: false,


### PR DESCRIPTION
When generating an APIM resource name, the service now
uses the shortened resource name, consistent with other resources.