### PR TITLE
fix: Add retry support when listing deployed functions

### DIFF
--- a/src/services/apimService.ts
+++ b/src/services/apimService.ts
@@ -216,7 +216,9 @@ export class ApimService extends BaseService {
         responses: options.operation.responses || [],
       };
 
-      const operationUrl = `${service.gatewayUrl}/${api.path}${operationConfig.urlTemplate}`;
+      // Ensure a single path seperator in the operation path
+      const operationPath = `/${api.path}/${operationConfig.urlTemplate}`.replace(/\/+/g, "/");
+      const operationUrl = `${service.gatewayUrl}${operationPath}`;
       this.log(`--> Deploying API operation ${options.function}: ${operationConfig.method.toUpperCase()} ${operationUrl}`);
 
       const operation = await client.apiOperation.createOrUpdate(

--- a/src/services/functionAppService.ts
+++ b/src/services/functionAppService.ts
@@ -106,7 +106,7 @@ export class FunctionAppService extends BaseService {
       return response.data.value.map((functionConfig) => functionConfig.properties);
     }
     catch (e) {
-      this.log("Unable to retrieve function app list");
+      this.log("-> Unable to retrieve function app list");
       return [];
     }
   }

--- a/src/services/functionAppService.ts
+++ b/src/services/functionAppService.ts
@@ -107,7 +107,7 @@ export class FunctionAppService extends BaseService {
     }
     catch (e) {
       this.log("-> Unable to retrieve function app list");
-      return [];
+      throw e;
     }
   }
 

--- a/src/services/functionAppService.ts
+++ b/src/services/functionAppService.ts
@@ -13,6 +13,8 @@ import { BaseService } from "./baseService";
 import { Utils } from "../shared/utils";
 
 export class FunctionAppService extends BaseService {
+  private static readonly retryCount: number = 10;
+  private static readonly retryInterval: number = 5000;
   private webClient: WebSiteManagementClient;
   private blobService: AzureBlobStorageService;
 
@@ -101,7 +103,7 @@ export class FunctionAppService extends BaseService {
         }
 
         return listFunctionsResponse;
-      }, 10, 5000);
+      }, FunctionAppService.retryCount, FunctionAppService.retryInterval);
 
       return response.data.value.map((functionConfig) => functionConfig.properties);
     }
@@ -132,7 +134,7 @@ export class FunctionAppService extends BaseService {
         }
 
         return getFunctionResponse;
-      }, 10, 5000);
+      }, FunctionAppService.retryCount, FunctionAppService.retryInterval);
 
       return response.data.properties;
     } catch (e) {

--- a/src/shared/utils.test.ts
+++ b/src/shared/utils.test.ts
@@ -168,4 +168,24 @@ describe("utils", () => {
       expect(lastRetry).toEqual(maxRetries);
     });
   });
+
+  describe("wait", () => {
+    const setTimeoutMock = jest.fn((resolve) => resolve());
+
+    beforeEach(() => {
+      global.setTimeout = setTimeoutMock;
+    });
+
+    it("waits 1000 by default", async () => {
+      await Utils.wait();
+
+      expect(setTimeoutMock).toBeCalledWith(expect.any(Function), 1000);
+    });
+
+    it("waits specified time", async () => {
+      await Utils.wait(2000);
+
+      expect(setTimeoutMock).toBeCalledWith(expect.any(Function), 2000);
+    });
+  });
 });

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -190,7 +190,7 @@ export class Utils {
    * Waits for the specified amount of time.
    * @param time The amount of time to wait (default = 1000ms)
    */
-  private static wait(time: number = 1000) {
+  public static wait(time: number = 1000) {
     return new Promise((resolve) => {
       setTimeout(resolve, time);
     });

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -160,4 +160,39 @@ export class Utils {
       return settings && settings.direction === "out";
     });
   }
+
+  /**
+   * Runs an operation with auto retry policy
+   * @param operation The operation to run
+   * @param maxRetries The max number or retreis
+   * @param retryWaitInterval The time to wait between retries
+   */
+  public static async runWithRetry<T>(operation: (retry?: number) => Promise<T>, maxRetries: number = 3, retryWaitInterval: number = 1000) {
+    let retry = 0;
+    let error = null;
+
+    while (retry < maxRetries) {
+      try {
+        retry++;
+        return await operation(retry);
+      }
+      catch (e) {
+        error = e;
+      }
+
+      await Utils.wait(retryWaitInterval);
+    }
+
+    return Promise.reject(error);
+  }
+
+  /**
+   * Waits for the specified amount of time.
+   * @param time The amount of time to wait (default = 1000ms)
+   */
+  private static wait(time: number = 1000) {
+    return new Promise((resolve) => {
+      setTimeout(resolve, time);
+    });
+  }
 }


### PR DESCRIPTION
When listing the deployed functions on 1st time deployment it may take some additional time to initialize the function app and extract the functions.  This adds a retry policy that will retry the function listing multiple times until the function app is fully ready.