### PR TITLE
fix: Inject current environment variables to spawn process

### DIFF
--- a/src/services/offlineService.ts
+++ b/src/services/offlineService.ts
@@ -80,18 +80,6 @@ export class OfflineService extends BaseService {
       const spawnOptions: SpawnOptions = { env, stdio: "inherit" };
       const childProcess = spawn(command, spawnArgs, spawnOptions);
 
-      childProcess.on("error", (err) => {
-        this.log(`${err}\n
-        Command: ${command}
-        Arguments: "${spawnArgs.join(" ")}"
-        Options: ${JSON.stringify(spawnOptions, null, 2)}\n
-        Make sure you've installed azure-func-core-tools. Run:\n
-        npm i azure-func-core-tools -g`, {
-          color: "red"
-        }, command);
-        reject(err);
-      });
-
       childProcess.on("exit", (code) => {
         if (code === 0) {
           resolve();


### PR DESCRIPTION
Not able to repro `ENOENT` error yet, but this PR should help with debugging.
- [x] Inject current environment variables to spawned process (most importantly, `PATH` so that an executable can be found)
- [x] Add additional log statements on errors for debugging purposes

See [this stack overflow answer](https://stackoverflow.com/a/27688805) for more details.