### PR TITLE
feat: Added general safe naming to Naming Service

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -5,6 +5,10 @@ export const configConstants = {
     rollback: true,
     runFromBlobUrl: false,
   },
+  nameMaxLengths: {
+    storageAccount: 24,
+    deployment: 64,
+  },
   functionAppApiPath: "/api/",
   functionAppDomain: ".azurewebsites.net",
   functionsAdminApiPath: "/admin/functions/",

--- a/src/services/azureNamingService.test.ts
+++ b/src/services/azureNamingService.test.ts
@@ -126,6 +126,26 @@ describe("Azure Naming Service", () => {
     expect(service.getPrefix()).toEqual("hello");
   });
 
+  it("generates safe deployment names", () => {
+    const serviceName = "thisismysuperlongservicenamethatnevereverevereverends";
+    const prefix = "thisismysuperlongprefixthatnevereverevereverends";
+    service = getService({
+      ...azureConfig,
+      provider: {
+        name: "azure",
+        region: "West US 2",
+        stage: "prod",
+        prefix,
+      },
+      service: serviceName
+    });
+
+    const nameHash = md5(serviceName)
+    const pattern = `${prefix.substr(0, 8)}-wus2-pro-${nameHash.substr(0, 6)}-deployment-t([0-9]+)`;
+
+    expect(service.getDeploymentName()).toMatch(new RegExp(pattern, "g"))
+  });
+
   describe("Resource names", () => {
 
     function assertValidStorageAccountName(config: ServerlessAzureConfig, value: string) {
@@ -162,7 +182,7 @@ describe("Azure Naming Service", () => {
 
       const result = service.getResourceName(ArmResourceType.StorageAccount)
       assertValidStorageAccountName(testConfig, result);
-      expect(result.startsWith("mylaussedev")).toBe(true);
+      expect(result.startsWith("myloaussedev")).toBe(true);
     });
 
     it("Generating a storage account name is idempotent", () => {


### PR DESCRIPTION
**IMPORTANT** - This is a pull request into a branch which **also** is an open PR.

- [x] Added max name length to config constants
- [x] Added some JS-Docs to naming service
- [x] Added general `generateSafeName` that is currently used in both storage account and deployment name generation
- [x] Updated `getConfiguredName` to be a little more clean
- [x] Add tests

Resolves [AB#597]