### PR TITLE
feat: Cache interactive login credentials

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4723,8 +4723,7 @@
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4742,13 +4741,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4761,18 +4758,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -4875,8 +4869,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -4886,7 +4879,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -4899,20 +4891,17 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
         },
         "minimist": {
           "version": "0.0.8",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -4929,7 +4918,6 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5002,8 +4990,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5013,7 +5000,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5089,8 +5075,7 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5120,7 +5105,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5138,7 +5122,6 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5177,13 +5160,11 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "yallist": {
           "version": "3.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         }
       }
     },

--- a/src/plugins/login/azureLoginPlugin.test.ts
+++ b/src/plugins/login/azureLoginPlugin.test.ts
@@ -68,7 +68,7 @@ describe("Login Plugin", () => {
       undefined // would be options
     )
     expect(AzureLoginService.interactiveLogin).not.toBeCalled();
-    expect(sls.variables["azureCredentials"]).toEqual(credentials);
+    expect(JSON.stringify(sls.variables["azureCredentials"])).toEqual(JSON.stringify(credentials));
     expect(sls.variables["subscriptionId"]).toEqual("azureSubId");
   });
 
@@ -78,7 +78,7 @@ describe("Login Plugin", () => {
     await invokeLoginHook(false, sls);
     expect(AzureLoginService.servicePrincipalLogin).not.toBeCalled();
     expect(AzureLoginService.interactiveLogin).toBeCalled();
-    expect(sls.variables["azureCredentials"]).toEqual(credentials);
+    expect(JSON.stringify(sls.variables["azureCredentials"])).toEqual(JSON.stringify(credentials));
     expect(sls.variables["subscriptionId"]).toEqual("azureSubId");
   });
 

--- a/src/plugins/login/azureLoginPlugin.ts
+++ b/src/plugins/login/azureLoginPlugin.ts
@@ -2,16 +2,12 @@ import Serverless from "serverless";
 import { AzureLoginOptions, AzureLoginService } from "../../services/loginService";
 import { AzureBasePlugin } from "../azureBasePlugin";
 import { loginHooks } from "./loginHooks";
-import { SimpleFileTokenCache } from "./utils/simpleFileTokenCache";
 
 export class AzureLoginPlugin extends AzureBasePlugin<AzureLoginOptions> {
-  private fileTokenCache: SimpleFileTokenCache;
   public hooks: { [eventName: string]: Promise<any> };
 
   public constructor(serverless: Serverless, options: AzureLoginOptions) {
     super(serverless, options);
-
-    this.fileTokenCache = new SimpleFileTokenCache();
 
     this.hooks = {};
     for (const h of loginHooks) {
@@ -28,13 +24,12 @@ export class AzureLoginPlugin extends AzureBasePlugin<AzureLoginOptions> {
     this.log("Logging into Azure");
 
     try {
-      const authResult = await AzureLoginService.login({tokenCache: this.fileTokenCache});
+      const authResult = await AzureLoginService.login();
       this.serverless.variables["azureCredentials"] = authResult.credentials;
       // Use environment variable for sub ID or use the first subscription in the list (service principal can
       // have access to more than one subscription)
       this.serverless.variables["subscriptionId"] = this.options.subscriptionId || process.env.azureSubId || this.serverless.service.provider["subscriptionId"] || authResult.subscriptions[0].id;
       this.serverless.cli.log(`Using subscription ID: ${this.serverless.variables["subscriptionId"]}`);
-      this.fileTokenCache.addSubs(authResult.subscriptions);
     }
     catch (e) {
       this.log("Error logging into azure");

--- a/src/plugins/login/azureLoginPlugin.ts
+++ b/src/plugins/login/azureLoginPlugin.ts
@@ -2,12 +2,16 @@ import Serverless from "serverless";
 import { AzureLoginOptions, AzureLoginService } from "../../services/loginService";
 import { AzureBasePlugin } from "../azureBasePlugin";
 import { loginHooks } from "./loginHooks";
+import { SimpleFileTokenCache } from "./utils/simpleFileTokenCache";
 
 export class AzureLoginPlugin extends AzureBasePlugin<AzureLoginOptions> {
+  private fileTokenCache: SimpleFileTokenCache;
   public hooks: { [eventName: string]: Promise<any> };
 
   public constructor(serverless: Serverless, options: AzureLoginOptions) {
     super(serverless, options);
+
+    this.fileTokenCache = new SimpleFileTokenCache();
 
     this.hooks = {};
     for (const h of loginHooks) {
@@ -24,12 +28,13 @@ export class AzureLoginPlugin extends AzureBasePlugin<AzureLoginOptions> {
     this.log("Logging into Azure");
 
     try {
-      const authResult = await AzureLoginService.login();
+      const authResult = await AzureLoginService.login({tokenCache: this.fileTokenCache});
       this.serverless.variables["azureCredentials"] = authResult.credentials;
       // Use environment variable for sub ID or use the first subscription in the list (service principal can
       // have access to more than one subscription)
       this.serverless.variables["subscriptionId"] = this.options.subscriptionId || process.env.azureSubId || this.serverless.service.provider["subscriptionId"] || authResult.subscriptions[0].id;
       this.serverless.cli.log(`Using subscription ID: ${this.serverless.variables["subscriptionId"]}`);
+      this.fileTokenCache.addSubs(authResult.subscriptions);
     }
     catch (e) {
       this.log("Error logging into azure");

--- a/src/plugins/login/utils/simpleFileTokenCache.test.ts
+++ b/src/plugins/login/utils/simpleFileTokenCache.test.ts
@@ -61,6 +61,7 @@ describe("Simple File Token Cache", () => {
 
     expect(tokenCache.isEmpty()).toBe(false);
     expect(writeFileSpy).toBeCalledWith(tokenFilePath, JSON.stringify(expected));
+    writeFileSpy.mockRestore();
   });
 
   it("Saves to file after subscription is added", () => {
@@ -78,5 +79,6 @@ describe("Simple File Token Cache", () => {
     };
 
     expect(writeFileSpy).toBeCalledWith(tokenFilePath, JSON.stringify(expected));
+    writeFileSpy.mockRestore();
   });
 });

--- a/src/plugins/login/utils/simpleFileTokenCache.test.ts
+++ b/src/plugins/login/utils/simpleFileTokenCache.test.ts
@@ -6,45 +6,80 @@ import { MockFactory } from "../../../test/mockFactory";
 import { SimpleFileTokenCache } from "./simpleFileTokenCache";
 
 describe("Simple File Token Cache", () => {
-  const CONFIG_DIRECTORY = path.join(os.homedir(), ".azure");
-  const SLS_TOKEN_FILE = path.join(CONFIG_DIRECTORY, "slsTokenCache.json");
-  const fileContent = JSON.stringify({
+  let fileContent = {
     _entries: [],
     subscriptions: [],
+  };
+  
+  beforeEach(() => {
+    fileContent = {
+      _entries: [],
+      subscriptions: [],
+    };
   });
   
   beforeAll(() => {
-    const fakeFs = {};
-    fakeFs[SLS_TOKEN_FILE] = fileContent;
-    mockFs(fakeFs, { createCwd: true, createTmp: true });
+    // const fakeFs = {};
+    // fakeFs[SLS_TOKEN_FILE] = fileContent;
+    // mockFs(fakeFs, { createCwd: true, createTmp: true });
     // mockFs({});
   });
 
   afterEach(() => {
-    jest.resetAllMocks();
     mockFs.restore();
+    jest.resetAllMocks();
   });
 
-  it("Tries to load file on creation", () => {
+  it("Creates a load file on creation if none", () => {
+    mockFs({});
+    const writeFileSpy = jest.spyOn(fs, "writeFileSync");
+    // const calls = readFileSpy.mock.calls;
+    const testFileCache = new SimpleFileTokenCache("./slsTokenCache.json");
+
+    expect(writeFileSpy).toBeCalledTimes(1);
+    // expect(calls).toHaveLength(1);
+    // expect([calls[0][0], calls[0][1]]).toEqual([SLS_TOKEN_FILE, {_entries: testEntries, subscriptions: []}]);
+  });
+
+  it("Load file on creation if available", () => {
+    const fakeFs = {};
+    fileContent._entries = MockFactory.createTestTokenCacheEntries();
+    fakeFs["./slsTokenCache.json"] = fileContent;
+    mockFs(fakeFs, { createCwd: true, createTmp: true });
     const readFileSpy = jest.spyOn(fs, "readFileSync");
     const calls = readFileSpy.mock.calls;
-    const testFileCache = new SimpleFileTokenCache();
+    const testFileCache = new SimpleFileTokenCache("./slsTokenCache.json");
 
-    expect(calls).toHaveLength(1);
-    expect([calls[0][0], calls[0][1]]).toEqual([SLS_TOKEN_FILE, {_entries: testEntries, subscriptions: []}]);
+    expect(readFileSpy).toBeCalledTimes(1);
+    // expect(calls).toHaveLength(1);
+    // expect([calls[0][0], calls[0][1]]).toEqual([SLS_TOKEN_FILE, {_entries: testEntries, subscriptions: []}]);
   })
 
   it("Saves to file after token is added", () => {
     const writeFileSpy = jest.spyOn(fs, "writeFileSync");
     const calls = writeFileSpy.mock.calls;
-    const testFileCache = new SimpleFileTokenCache();
+    const testFileCache = new SimpleFileTokenCache("./");
     const testEntries = MockFactory.createTestTokenCacheEntries();
 
-
     testFileCache.add(testEntries);
+
+    expect(testFileCache.isEmpty()).toBe(false);
+    expect(writeFileSpy).toBeCalledTimes(1);
+    // expect(calls).toHaveLength(1);
+    // expect([calls[0][0], calls[0][1]]).toEqual([SLS_TOKEN_FILE, {_entries: testEntries, subscriptions: []}]);
+  });
+
+  it("Saves to file after subscription is added", () => {
+    const writeFileSpy = jest.spyOn(fs, "writeFileSync");
+    const calls = writeFileSpy.mock.calls;
+    const testFileCache = new SimpleFileTokenCache("./");
+    const testSubs = MockFactory.createTestSubscriptions();
+
+
+    testFileCache.addSubs(testSubs);
 
     expect(writeFileSpy).toBeCalledTimes(1);
     // expect(calls).toHaveLength(1);
     // expect([calls[0][0], calls[0][1]]).toEqual([SLS_TOKEN_FILE, {_entries: testEntries, subscriptions: []}]);
-  })
+  });
 });

--- a/src/plugins/login/utils/simpleFileTokenCache.test.ts
+++ b/src/plugins/login/utils/simpleFileTokenCache.test.ts
@@ -1,0 +1,50 @@
+import fs from "fs";
+import mockFs from "mock-fs";
+import path from "path";
+import os from "os";
+import { MockFactory } from "../../../test/mockFactory";
+import { SimpleFileTokenCache } from "./simpleFileTokenCache";
+
+describe("Simple File Token Cache", () => {
+  const CONFIG_DIRECTORY = path.join(os.homedir(), ".azure");
+  const SLS_TOKEN_FILE = path.join(CONFIG_DIRECTORY, "slsTokenCache.json");
+  const fileContent = JSON.stringify({
+    _entries: [],
+    subscriptions: [],
+  });
+  
+  beforeAll(() => {
+    const fakeFs = {};
+    fakeFs[SLS_TOKEN_FILE] = fileContent;
+    mockFs(fakeFs, { createCwd: true, createTmp: true });
+    // mockFs({});
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+    mockFs.restore();
+  });
+
+  it("Tries to load file on creation", () => {
+    const readFileSpy = jest.spyOn(fs, "readFileSync");
+    const calls = readFileSpy.mock.calls;
+    const testFileCache = new SimpleFileTokenCache();
+
+    expect(calls).toHaveLength(1);
+    expect([calls[0][0], calls[0][1]]).toEqual([SLS_TOKEN_FILE, {_entries: testEntries, subscriptions: []}]);
+  })
+
+  it("Saves to file after token is added", () => {
+    const writeFileSpy = jest.spyOn(fs, "writeFileSync");
+    const calls = writeFileSpy.mock.calls;
+    const testFileCache = new SimpleFileTokenCache();
+    const testEntries = MockFactory.createTestTokenCacheEntries();
+
+
+    testFileCache.add(testEntries);
+
+    expect(writeFileSpy).toBeCalledTimes(1);
+    // expect(calls).toHaveLength(1);
+    // expect([calls[0][0], calls[0][1]]).toEqual([SLS_TOKEN_FILE, {_entries: testEntries, subscriptions: []}]);
+  })
+});

--- a/src/plugins/login/utils/simpleFileTokenCache.ts
+++ b/src/plugins/login/utils/simpleFileTokenCache.ts
@@ -14,53 +14,53 @@ export class SimpleFileTokenCache implements adal.TokenCache {
     this.load();
   }
 
-  public add(entries: any, cb?: any) {
+  public add(entries: any[], callback?: (err?: Error, result?: boolean) => void) {
     this.entries.push(...entries);
     this.save();
-    if (cb) {
-      cb();
+    if (callback) {
+      callback();
     }
   }
 
-  public remove(entries: any, cb?: any) {
+  public remove(entries: any[], callback?: (err?: Error, result?: null) => void) {
     this.entries = this.entries.filter(e => {
       return !Object.keys(entries[0]).every(key => e[key] === entries[0][key]);
     });
     this.save();
-    if (cb) {
-      cb();
+    if (callback) {
+      callback();
     }
   }
 
-  public find(query: any, cb?: any) {
+  public find(query: any, callback: (err?: Error, result?: any[]) => void) {
     let result = this.entries.filter(e => {
       return Object.keys(query).every(key => e[key] === query[key]);
     });
-    cb(null, result);
+    callback(null, result);
     return result;
   }
 
   //-------- File toke cache specific methods
 
-  public addSubs(entries: any) {
-    this.subscriptions.push(...entries);
-    this.subscriptions = this.subscriptions.reduce((acc, current) => {
-      const x = acc.find(item => item.id === current.id);
+  public addSubs(subscriptions: any) {
+    this.subscriptions.push(...subscriptions);
+    this.subscriptions = this.subscriptions.reduce((accumulator , current) => {
+      const x = accumulator .find(item => item.id === current.id);
       if (!x) {
-        return acc.concat([current]);
+        return accumulator .concat([current]);
       } else {
-        return acc;
+        return accumulator ;
       }
     }, []);
     this.save();
   }
 
 
-  public clear(cb: any) {
+  public clear(callback: any) {
     this.entries = [];
     this.subscriptions = [];
     this.save();
-    cb();
+    callback();
   }
 
   public isEmpty() {

--- a/src/plugins/login/utils/simpleFileTokenCache.ts
+++ b/src/plugins/login/utils/simpleFileTokenCache.ts
@@ -10,28 +10,28 @@ export class SimpleFileTokenCache implements adal.TokenCache{
   private _entries: any[] = [];
   private subscriptions: any[] = [];
   public constructor() {
-    console.log("new Simple file toke cache");
     this.load();
   }
 
-  public add(entries: any, cb: any) {
-    console.log("adding")
+  public add(entries: any, cb?: any) {
     this._entries.push(...entries);
     this.save();
-    cb();
+    if(cb) {
+      cb();
+    }
   }
 
-  public remove(entries: any, cb: any) {
-    console.log("remove")
+  public remove(entries: any, cb?: any) {
     this._entries = this._entries.filter(e => {
       return !Object.keys(entries[0]).every(key => e[key] === entries[0][key]);
     });
     this.save();
-    cb();
+    if(cb) {
+      cb();
+    }
   }
 
-  public find(query, cb) {
-    console.log("find")
+  public find(query: any, cb?: any) {
     let result = this._entries.filter(e => {
       return Object.keys(query).every(key => e[key] === query[key]);
     });
@@ -42,14 +42,20 @@ export class SimpleFileTokenCache implements adal.TokenCache{
   //-------- File toke cache specific methods
 
   public addSubs(entries: any) {
-    console.log("adding")
     this.subscriptions.push(...entries);
+    this.subscriptions = this.subscriptions.reduce((acc, current) => {
+      const x = acc.find(item => item.id === current.id);
+      if (!x) {
+        return acc.concat([current]);
+      } else {
+        return acc;
+      }
+    }, []);
     this.save();
   }
 
 
   public clear(cb: any) {
-    console.log("clear");
     this._entries = [];
     this.subscriptions = [];
     this.save();
@@ -57,8 +63,6 @@ export class SimpleFileTokenCache implements adal.TokenCache{
   }
 
   public isEmpty() {
-    console.log("empty")
-    // this.deleteOld();
     return this._entries.length === 0;
   }
 
@@ -76,20 +80,12 @@ export class SimpleFileTokenCache implements adal.TokenCache{
       this._entries = savedCache._entries;
       this._entries.map(t => t.expiresOn = new Date(t.expiresOn))
       this.subscriptions = savedCache.subscriptions;
-      console.log("loaded");
     } catch (e) {
-      console.log("not loaded");
+      console.log("Error Loading");
     }
   }
 
   public save() {
-    console.log("save")
     fs.writeFileSync(SLS_TOKEN_FILE, JSON.stringify({_entries: this._entries, subscriptions: this.subscriptions}));
-  }
-
-  private deleteOld() {
-    this._entries = this._entries.filter(
-      t => t.expiresOn > Date.now() - 5 * 60 * 1000
-    );
   }
 }

--- a/src/plugins/login/utils/simpleFileTokenCache.ts
+++ b/src/plugins/login/utils/simpleFileTokenCache.ts
@@ -1,28 +1,45 @@
 import * as fs from "fs";
 import path from "path";
 import os from "os";
+import * as adal from "adal-node";
 
 const CONFIG_DIRECTORY = path.join(os.homedir(), ".azure");
 const SLS_TOKEN_FILE = path.join(CONFIG_DIRECTORY, "slsTokenCache.json");
 
-export class SimpleFileTokenCache {
-  private tokens: any[] = [];
+export class SimpleFileTokenCache implements adal.TokenCache{
+  private _entries: any[] = [];
   private subscriptions: any[] = [];
   public constructor() {
     console.log("new Simple file toke cache");
     this.load();
   }
 
-  public isSecureCache() {
-    throw "isSecureCache not implemented";
-  }
-
   public add(entries: any, cb: any) {
     console.log("adding")
-    this.tokens.push(...entries);
+    this._entries.push(...entries);
     this.save();
     cb();
   }
+
+  public remove(entries: any, cb: any) {
+    console.log("remove")
+    this._entries = this._entries.filter(e => {
+      return !Object.keys(entries[0]).every(key => e[key] === entries[0][key]);
+    });
+    this.save();
+    cb();
+  }
+
+  public find(query, cb) {
+    console.log("find")
+    let result = this._entries.filter(e => {
+      return Object.keys(query).every(key => e[key] === query[key]);
+    });
+    cb(null, result);
+    return result;
+  }
+
+  //-------- File toke cache specific methods
 
   public addSubs(entries: any) {
     console.log("adding")
@@ -30,40 +47,23 @@ export class SimpleFileTokenCache {
     this.save();
   }
 
-  public remove(entries: any, cb: any) {
-    console.log("remove")
-    this.tokens = this.tokens.filter(e => {
-      return !Object.keys(entries[0]).every(key => e[key] === entries[0][key]);
-    });
-    this.save();
-    cb();
-  }
 
   public clear(cb: any) {
     console.log("clear");
-    this.tokens = [];
+    this._entries = [];
     this.subscriptions = [];
     this.save();
     cb();
   }
 
-  public find(query, cb) {
-    console.log("find")
-    let result = this.tokens.filter(e => {
-      return Object.keys(query).every(key => e[key] === query[key]);
-    });
-    cb(null, result);
-    return result;
-  }
-
-  public empty() {
+  public isEmpty() {
     console.log("empty")
     // this.deleteOld();
-    return this.tokens.length === 0;
+    return this._entries.length === 0;
   }
 
   public first() {
-    return this.tokens[0];
+    return this._entries[0];
   }
 
   public listSubscriptions() {
@@ -73,19 +73,22 @@ export class SimpleFileTokenCache {
   private load() {
     try {
       let savedCache = JSON.parse(fs.readFileSync(SLS_TOKEN_FILE).toString());
-      this.tokens = savedCache.tokens;
-      this.tokens.map(t => t.expiresOn = new Date(t.expiresOn))
+      this._entries = savedCache._entries;
+      this._entries.map(t => t.expiresOn = new Date(t.expiresOn))
       this.subscriptions = savedCache.subscriptions;
-    } catch (e) {}
+      console.log("loaded");
+    } catch (e) {
+      console.log("not loaded");
+    }
   }
 
   public save() {
     console.log("save")
-    fs.writeFileSync(SLS_TOKEN_FILE, JSON.stringify({tokens: this.tokens, subscriptions: this.subscriptions}));
+    fs.writeFileSync(SLS_TOKEN_FILE, JSON.stringify({_entries: this._entries, subscriptions: this.subscriptions}));
   }
 
   private deleteOld() {
-    this.tokens = this.tokens.filter(
+    this._entries = this._entries.filter(
       t => t.expiresOn > Date.now() - 5 * 60 * 1000
     );
   }

--- a/src/plugins/login/utils/simpleFileTokenCache.ts
+++ b/src/plugins/login/utils/simpleFileTokenCache.ts
@@ -1,4 +1,4 @@
-import * as fs from "fs";
+import fs from "fs";
 import path from "path";
 import os from "os";
 import * as adal from "adal-node";
@@ -6,35 +6,34 @@ import * as adal from "adal-node";
 const CONFIG_DIRECTORY = path.join(os.homedir(), ".azure");
 const DEFAULT_SLS_TOKEN_FILE = path.join(CONFIG_DIRECTORY, "slsTokenCache.json");
 
-export class SimpleFileTokenCache implements adal.TokenCache{
-  private _entries: any[] = [];
+export class SimpleFileTokenCache implements adal.TokenCache {
+  private entries: any[] = [];
   private subscriptions: any[] = [];
-  private tokePath: string;
-  public constructor(tokenPath: string = DEFAULT_SLS_TOKEN_FILE) {
-    this.tokePath = tokenPath;
+
+  public constructor(private tokenPath: string = DEFAULT_SLS_TOKEN_FILE) {
     this.load();
   }
 
   public add(entries: any, cb?: any) {
-    this._entries.push(...entries);
+    this.entries.push(...entries);
     this.save();
-    if(cb) {
+    if (cb) {
       cb();
     }
   }
 
   public remove(entries: any, cb?: any) {
-    this._entries = this._entries.filter(e => {
+    this.entries = this.entries.filter(e => {
       return !Object.keys(entries[0]).every(key => e[key] === entries[0][key]);
     });
     this.save();
-    if(cb) {
+    if (cb) {
       cb();
     }
   }
 
   public find(query: any, cb?: any) {
-    let result = this._entries.filter(e => {
+    let result = this.entries.filter(e => {
       return Object.keys(query).every(key => e[key] === query[key]);
     });
     cb(null, result);
@@ -58,37 +57,36 @@ export class SimpleFileTokenCache implements adal.TokenCache{
 
 
   public clear(cb: any) {
-    this._entries = [];
+    this.entries = [];
     this.subscriptions = [];
     this.save();
     cb();
   }
 
   public isEmpty() {
-    return this._entries.length === 0;
+    return this.entries.length === 0;
   }
 
   public first() {
-    return this._entries[0];
+    return this.entries[0];
   }
 
   public listSubscriptions() {
     return this.subscriptions;
   }
-  
+
   private load() {
-    if(fs.existsSync(this.tokePath)){
-      let savedCache = JSON.parse(fs.readFileSync(this.tokePath).toString());
-      this._entries = savedCache._entries;
-      this._entries.map(t => t.expiresOn = new Date(t.expiresOn))
+    if (fs.existsSync(this.tokenPath)) {
+      let savedCache = JSON.parse(fs.readFileSync(this.tokenPath).toString());
+      this.entries = savedCache.entries;
+      this.entries.map(t => t.expiresOn = new Date(t.expiresOn))
       this.subscriptions = savedCache.subscriptions;
     } else {
-      // console.log("No saved cache to load, creating new file cache");
       this.save();
     }
   }
 
   public save() {
-    fs.writeFileSync(this.tokePath, JSON.stringify({_entries: this._entries, subscriptions: this.subscriptions}));
+    fs.writeFileSync(this.tokenPath, JSON.stringify({ entries: this.entries, subscriptions: this.subscriptions }));
   }
 }

--- a/src/plugins/login/utils/simpleFileTokenCache.ts
+++ b/src/plugins/login/utils/simpleFileTokenCache.ts
@@ -1,0 +1,92 @@
+import * as fs from "fs";
+import path from "path";
+import os from "os";
+
+const CONFIG_DIRECTORY = path.join(os.homedir(), ".azure");
+const SLS_TOKEN_FILE = path.join(CONFIG_DIRECTORY, "slsTokenCache.json");
+
+export class SimpleFileTokenCache {
+  private tokens: any[] = [];
+  private subscriptions: any[] = [];
+  public constructor() {
+    console.log("new Simple file toke cache");
+    this.load();
+  }
+
+  public isSecureCache() {
+    throw "isSecureCache not implemented";
+  }
+
+  public add(entries: any, cb: any) {
+    console.log("adding")
+    this.tokens.push(...entries);
+    this.save();
+    cb();
+  }
+
+  public addSubs(entries: any) {
+    console.log("adding")
+    this.subscriptions.push(...entries);
+    this.save();
+  }
+
+  public remove(entries: any, cb: any) {
+    console.log("remove")
+    this.tokens = this.tokens.filter(e => {
+      return !Object.keys(entries[0]).every(key => e[key] === entries[0][key]);
+    });
+    this.save();
+    cb();
+  }
+
+  public clear(cb: any) {
+    console.log("clear");
+    this.tokens = [];
+    this.subscriptions = [];
+    this.save();
+    cb();
+  }
+
+  public find(query, cb) {
+    console.log("find")
+    let result = this.tokens.filter(e => {
+      return Object.keys(query).every(key => e[key] === query[key]);
+    });
+    cb(null, result);
+    return result;
+  }
+
+  public empty() {
+    console.log("empty")
+    // this.deleteOld();
+    return this.tokens.length === 0;
+  }
+
+  public first() {
+    return this.tokens[0];
+  }
+
+  public listSubscriptions() {
+    return this.subscriptions;
+  }
+  
+  private load() {
+    try {
+      let savedCache = JSON.parse(fs.readFileSync(SLS_TOKEN_FILE).toString());
+      this.tokens = savedCache.tokens;
+      this.tokens.map(t => t.expiresOn = new Date(t.expiresOn))
+      this.subscriptions = savedCache.subscriptions;
+    } catch (e) {}
+  }
+
+  public save() {
+    console.log("save")
+    fs.writeFileSync(SLS_TOKEN_FILE, JSON.stringify({tokens: this.tokens, subscriptions: this.subscriptions}));
+  }
+
+  private deleteOld() {
+    this.tokens = this.tokens.filter(
+      t => t.expiresOn > Date.now() - 5 * 60 * 1000
+    );
+  }
+}

--- a/src/services/baseService.ts
+++ b/src/services/baseService.ts
@@ -139,7 +139,7 @@ export abstract class BaseService {
     options: any = {}
   ) {
     const defaultHeaders = {
-      Authorization: `Bearer ${this.getAccessToken()}`
+      Authorization: `Bearer ${await this.getAccessToken()}`
     };
 
     const allHeaders = {

--- a/src/services/baseService.ts
+++ b/src/services/baseService.ts
@@ -14,7 +14,6 @@ import {
 } from "../models/serverless";
 import { Guard } from "../shared/guard";
 import { Utils } from "../shared/utils";
-import { SimpleFileTokenCache } from "../plugins/login/utils/simpleFileTokenCache";
 
 export abstract class BaseService {
   protected baseUrl: string;
@@ -124,8 +123,8 @@ export abstract class BaseService {
   /**
    * Get the access token from credentials token cache
    */
-  protected getAccessToken(): string {
-    return (this.credentials.tokenCache as SimpleFileTokenCache).first().accessToken;
+  protected async getAccessToken(): Promise<string> {
+    return this.credentials.getToken().then((result) => result.accessToken);
   }
 
   /**

--- a/src/services/baseService.ts
+++ b/src/services/baseService.ts
@@ -132,7 +132,7 @@ export abstract class BaseService {
    * Sends an API request using axios HTTP library
    * @param method The HTTP method
    * @param relativeUrl The relative url
-   * @param options Additional HTTP options including headers, etc
+   * @param options Additional HTTP options including headers, etc.
    */
   protected async sendApiRequest(
     method: string,

--- a/src/services/baseService.ts
+++ b/src/services/baseService.ts
@@ -124,7 +124,8 @@ export abstract class BaseService {
    * Get the access token from credentials token cache
    */
   protected async getAccessToken(): Promise<string> {
-    return this.credentials.getToken().then((result) => result.accessToken);
+    const token = await this.credentials.getToken();
+    return token ? token.accessToken : null;
   }
 
   /**

--- a/src/services/baseService.ts
+++ b/src/services/baseService.ts
@@ -14,6 +14,7 @@ import {
 } from "../models/serverless";
 import { Guard } from "../shared/guard";
 import { Utils } from "../shared/utils";
+import { SimpleFileTokenCache } from "../plugins/login/utils/simpleFileTokenCache";
 
 export abstract class BaseService {
   protected baseUrl: string;
@@ -124,7 +125,7 @@ export abstract class BaseService {
    * Get the access token from credentials token cache
    */
   protected getAccessToken(): string {
-    return (this.credentials.tokenCache as any)._entries[0].accessToken;
+    return (this.credentials.tokenCache as SimpleFileTokenCache).first().accessToken;
   }
 
   /**

--- a/src/services/functionAppService.test.ts
+++ b/src/services/functionAppService.test.ts
@@ -211,7 +211,7 @@ describe("Function App Service", () => {
       uri: expectedUploadUrl,
       json: true,
       headers: {
-        Authorization: `Bearer ${variables["azureCredentials"].tokenCache._entries[0].accessToken}`,
+        Authorization: `Bearer ${(await variables["azureCredentials"].getToken()).accessToken}`,
         Accept: "*/*",
         ContentType: "application/octet-stream",
       }
@@ -242,7 +242,7 @@ describe("Function App Service", () => {
       uri: expectedUploadUrl,
       json: true,
       headers: {
-        Authorization: `Bearer ${variables["azureCredentials"].tokenCache._entries[0].accessToken}`,
+        Authorization: `Bearer ${(await variables["azureCredentials"].getToken()).accessToken}`,
         Accept: "*/*",
         ContentType: "application/octet-stream",
       }
@@ -276,7 +276,7 @@ describe("Function App Service", () => {
       uri: expectedUploadUrl,
       json: true,
       headers: {
-        Authorization: `Bearer ${variables["azureCredentials"].tokenCache._entries[0].accessToken}`,
+        Authorization: `Bearer ${(await variables["azureCredentials"].getToken()).accessToken}`,
         Accept: "*/*",
         ContentType: "application/octet-stream",
       }

--- a/src/services/functionAppService.ts
+++ b/src/services/functionAppService.ts
@@ -159,7 +159,7 @@ export class FunctionAppService extends BaseService {
       uri: `https://${scmDomain}/api/zipdeploy/`,
       json: true,
       headers: {
-        Authorization: `Bearer ${this.getAccessToken()}`,
+        Authorization: `Bearer ${await this.getAccessToken()}`,
         Accept: "*/*",
         ContentType: "application/octet-stream",
       }

--- a/src/services/loginService.test.ts
+++ b/src/services/loginService.test.ts
@@ -2,21 +2,50 @@ import { AzureLoginService } from "./loginService";
 jest.mock("open");
 import open from "open";
 
-jest.mock("@azure/ms-rest-nodeauth")
-import { interactiveLoginWithAuthResponse, loginWithServicePrincipalSecretWithAuthResponse } from "@azure/ms-rest-nodeauth";
+jest.mock("@azure/ms-rest-nodeauth");
+import * as nodeauth from "@azure/ms-rest-nodeauth";
+
+jest.mock("../plugins/login/utils/simpleFileTokenCache");
+import { SimpleFileTokenCache } from "../plugins/login/utils/simpleFileTokenCache";
 
 describe("Login Service", () => {
-  
-  it("logs in interactively", async () => {
+
+  it("logs in interactively with no cached login", async () => {
     // Ensure env variables are not set
     delete process.env.azureSubId;
     delete process.env.azureServicePrincipalClientId;
     delete process.env.azureServicePrincipalPassword;
     delete process.env.azureServicePrincipalTenantId;
 
+    SimpleFileTokenCache.prototype.isEmpty = jest.fn(() => true);
+
+    const emptyObj = { subscriptions: [] };
+    Object.defineProperty(nodeauth,
+      "interactiveLoginWithAuthResponse",
+      { value: jest.fn(_obj => emptyObj) }
+    );
+
     await AzureLoginService.login();
-    expect(open).toBeCalledWith("https://microsoft.com/devicelogin")
-    expect(interactiveLoginWithAuthResponse).toBeCalled();
+    expect(SimpleFileTokenCache).toBeCalled();
+    expect(open).toBeCalledWith("https://microsoft.com/devicelogin");
+    expect(nodeauth.interactiveLoginWithAuthResponse).toBeCalled();
+    expect(SimpleFileTokenCache.prototype.addSubs).toBeCalledWith(emptyObj.subscriptions);
+  });
+
+  it("logs in interactively with a cached login", async () => {
+    // Ensure env variables are not set
+    delete process.env.azureSubId;
+    delete process.env.azureServicePrincipalClientId;
+    delete process.env.azureServicePrincipalPassword;
+    delete process.env.azureServicePrincipalTenantId;
+
+    SimpleFileTokenCache.prototype.isEmpty = jest.fn(() => false);
+    SimpleFileTokenCache.prototype.first = jest.fn(() => ({ userId: "" }));
+
+    await AzureLoginService.login();
+    expect(SimpleFileTokenCache).toBeCalled();
+    expect(nodeauth.DeviceTokenCredentials).toBeCalled();
+    expect(SimpleFileTokenCache.prototype.listSubscriptions).toBeCalled();
   });
 
   it("logs in with a service principal", async () => {
@@ -27,7 +56,7 @@ describe("Login Service", () => {
     process.env.azureServicePrincipalTenantId = "azureServicePrincipalTenantId";
 
     await AzureLoginService.login();
-    expect(loginWithServicePrincipalSecretWithAuthResponse).toBeCalledWith(
+    expect(nodeauth.loginWithServicePrincipalSecretWithAuthResponse).toBeCalledWith(
       "azureServicePrincipalClientId",
       "azureServicePrincipalPassword",
       "azureServicePrincipalTenantId",

--- a/src/services/loginService.test.ts
+++ b/src/services/loginService.test.ts
@@ -32,7 +32,7 @@ describe("Login Service", () => {
     expect(SimpleFileTokenCache.prototype.addSubs).toBeCalledWith(emptyObj.subscriptions);
   });
 
-  it("logs in interactively with a cached login", async () => {
+  it("logs in with a cached login", async () => {
     // Ensure env variables are not set
     delete process.env.azureSubId;
     delete process.env.azureServicePrincipalClientId;

--- a/src/services/loginService.ts
+++ b/src/services/loginService.ts
@@ -37,11 +37,9 @@ export class AzureLoginService {
     let authResp: AuthResponse = {credentials: undefined, subscriptions: []};
     const fileTokenCache = new SimpleFileTokenCache();
     if(!fileTokenCache.isEmpty()){
-      console.log("not empty");
       authResp.credentials = new DeviceTokenCredentials(undefined, undefined, fileTokenCache.first().userId, undefined, undefined, fileTokenCache);
       authResp.subscriptions = fileTokenCache.listSubscriptions();
     } else {
-      console.log("need to do interactive login now");
       await open("https://microsoft.com/devicelogin");
       authResp = await interactiveLoginWithAuthResponse({...options, tokenCache: fileTokenCache});
       fileTokenCache.addSubs(authResp.subscriptions);

--- a/src/services/loginService.ts
+++ b/src/services/loginService.ts
@@ -36,13 +36,13 @@ export class AzureLoginService {
   public static async interactiveLogin(options?: InteractiveLoginOptions): Promise<AuthResponse> {
     let authResp: AuthResponse = {credentials: undefined, subscriptions: []};
     const fileTokenCache = new SimpleFileTokenCache();
-    if(!fileTokenCache.isEmpty()){
-      authResp.credentials = new DeviceTokenCredentials(undefined, undefined, fileTokenCache.first().userId, undefined, undefined, fileTokenCache);
-      authResp.subscriptions = fileTokenCache.listSubscriptions();
-    } else {
+    if(fileTokenCache.isEmpty()){
       await open("https://microsoft.com/devicelogin");
       authResp = await interactiveLoginWithAuthResponse({...options, tokenCache: fileTokenCache});
       fileTokenCache.addSubs(authResp.subscriptions);
+    } else {
+      authResp.credentials = new DeviceTokenCredentials(undefined, undefined, fileTokenCache.first().userId, undefined, undefined, fileTokenCache);
+      authResp.subscriptions = fileTokenCache.listSubscriptions();
     }
 
     return authResp;

--- a/src/test/mockFactory.ts
+++ b/src/test/mockFactory.ts
@@ -376,15 +376,7 @@ export class MockFactory {
 
   public static createTestVariables() {
     return {
-      azureCredentials: {
-        tokenCache: {
-          _entries: [
-            {
-              accessToken: "token"
-            }
-          ]
-        }
-      },
+      azureCredentials: this.createTestAzureCredentials(),
       subscriptionId: "azureSubId",
     }
   }

--- a/src/test/mockFactory.ts
+++ b/src/test/mockFactory.ts
@@ -126,25 +126,17 @@ export class MockFactory {
   public static createTestAzureCredentials(): TokenClientCredentials {
     const credentials = {
       getToken: jest.fn(() => {
-        const token: TokenResponse = {
-          tokenType: "Bearer",
-          accessToken: "ABC123",
-        };
+        const token: TokenResponse = this.createTestTokenCacheEntries()[0];
 
         return Promise.resolve(token);
       }),
       signRequest: jest.fn((resource) => Promise.resolve(resource)),
     };
 
-    // TODO: Reduce usage on tokenCache._entries[0]
-    credentials["tokenCache"] = {
-      _entries: [this.createTestTokenCacheEntries()]
-    };
-
     return credentials;
   }
 
-  public static createTestTokenCacheEntries(count: number = 1): any[] {
+  public static createTestTokenCacheEntries(count: number = 1): TokenResponse[] {
     const token: TokenResponse = {
       tokenType: "Bearer",
       accessToken: "ABC123",

--- a/src/test/mockFactory.ts
+++ b/src/test/mockFactory.ts
@@ -138,10 +138,21 @@ export class MockFactory {
 
     // TODO: Reduce usage on tokenCache._entries[0]
     credentials["tokenCache"] = {
-      _entries: [{ accessToken: "ABC123" }]
+      _entries: [this.createTestTokenCacheEntries()]
     };
 
     return credentials;
+  }
+
+  public static createTestTokenCacheEntries(count: number = 1): any[] {
+    const token: TokenResponse = {
+      tokenType: "Bearer",
+      accessToken: "ABC123",
+      userId: "example@user.com",
+    };
+    const result = Array(count).fill(token);
+
+    return result;
   }
 
   public static createTestTimestamp(): string {

--- a/src/test/mockFactory.ts
+++ b/src/test/mockFactory.ts
@@ -155,6 +155,20 @@ export class MockFactory {
     return result;
   }
 
+  public static createTestSubscriptions(count: number = 1): any[] {
+    const sub = {
+      id: "abc-1234-5678",
+      state: "Enabled",
+      authorizationSource: "RoleBased",
+      user: { name: "example@user.com", type: "user" },
+      environmentName: "AzureCloud",
+      name: "Test Sub"
+    };
+    const result = Array(count).fill(sub);
+
+    return result;
+  }
+
   public static createTestTimestamp(): string {
     return "1562184492";
   }


### PR DESCRIPTION
feat: Cache interactive login credentials

Currently once a user logs in using the interactive login, there is no way to cache the credentials and the user must keep logging in through that method. This adds a simple file token cache that saves the credentials and subscription information and then uses those to login, reducing number of logins required. 

AB#359