### PR TITLE
feat: Deploy function app code from blob storage URL

### DIFF
--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -69,22 +69,25 @@ then user try to deploy
 ```yml
 service: my-app
 provider:
-  ...
+  deployment:
+    # Rollback enabled, deploying to blob storage
+    # Default is true
+    # If false, deploys directly to function app
+    rollback: true
+    # Container in blob storage containing deployed packages
+    # Default is DEPLOYMENT_ARTIFACTS
+    container: MY_CONTAINER_NAME
+    # Sets the WEBSITE_RUN_FROM_PACKAGE setting of function app
+    # to the SAS url of the artifact sitting in blob storage
+    # Recommended when using linux, not recommended when using windows
+    # Default is false
+    runFromBlobUrl: true
 
 plugins:
   - serverless-azure-functions
 
 package:
   ...
-
-deploy:
-  # Rollback enabled, deploying to blob storage
-  # Default is true
-  # If false, deploys directly to function app
-  rollback: true
-  # Container in blob storage containing deployed packages
-  # Default is DEPLOYMENT_ARTIFACTS
-  container: MY_CONTAINER_NAME
 
 functions:
   ...

--- a/src/config.ts
+++ b/src/config.ts
@@ -22,6 +22,7 @@ export const configConstants = {
   funcCoreTools: "func",
   funcCoreToolsArgs: ["host", "start"],
   funcConsoleColor: "blue",
+  runFromPackageSetting: "WEBSITE_RUN_FROM_PACKAGE",
   jsonContentType: "application/json",
   logInvocationsApiPath: "/azurejobs/api/functions/definitions/",
   logOutputApiPath: "/azurejobs/api/log/output/",

--- a/src/models/serverless.ts
+++ b/src/models/serverless.ts
@@ -39,6 +39,7 @@ export interface ServerlessAzureProvider {
   environment?: {
     [key: string]: any;
   };
+  deployment?: DeploymentConfig;
   deploymentName?: string;
   resourceGroup?: string;
   apim?: ApiManagementConfig;

--- a/src/plugins/login/azureLoginPlugin.test.ts
+++ b/src/plugins/login/azureLoginPlugin.test.ts
@@ -52,6 +52,7 @@ describe("Login Plugin", () => {
   });
 
   it("calls login if azure credentials are not set", async () => {
+    unsetServicePrincipalEnvVariables();
     await invokeLoginHook();
     expect(AzureLoginService.interactiveLogin).toBeCalled();
     expect(AzureLoginService.servicePrincipalLogin).not.toBeCalled();
@@ -115,7 +116,7 @@ describe("Login Plugin", () => {
     expect(sls.variables["subscriptionId"]).toEqual("azureSubId");
     expect(sls.cli.log).toBeCalledWith("Using subscription ID: azureSubId");
   });
-  
+
   it("Uses the subscription ID specified in serverless yaml", async () => {
     const sls = MockFactory.createTestServerless();
     const opt = MockFactory.createTestServerlessOptions();

--- a/src/services/baseService.ts
+++ b/src/services/baseService.ts
@@ -190,6 +190,10 @@ export abstract class BaseService {
     (this.serverless.cli.log as any)(message, entity, options);
   }
 
+  protected prettyPrint(object: any) {
+    this.log(JSON.stringify(object, null, 2));
+  }
+
   /**
    * Get function objects
    */

--- a/src/services/baseService.ts
+++ b/src/services/baseService.ts
@@ -23,6 +23,7 @@ export abstract class BaseService {
   protected subscriptionId: string;
   protected resourceGroup: string;
   protected deploymentName: string;
+  protected artifactName: string;
   protected deploymentConfig: DeploymentConfig;
   protected storageAccountName: string;
   protected config: ServerlessAzureConfig;
@@ -43,6 +44,7 @@ export abstract class BaseService {
     this.resourceGroup = this.getResourceGroupName();
     this.deploymentConfig = this.getDeploymentConfig();
     this.deploymentName = this.getDeploymentName();
+    this.artifactName = this.getArtifactName(this.deploymentName);
     this.storageAccountName = StorageAccountResource.getResourceName(this.config);
 
     if (!this.credentials && authenticate) {
@@ -84,10 +86,9 @@ export abstract class BaseService {
    * Defaults can be found in the `config.ts` file
    */
   public getDeploymentConfig(): DeploymentConfig {
-    const providedConfig = this.serverless["deploy"] as DeploymentConfig;
     return {
       ...configConstants.deploymentConfig,
-      ...providedConfig,
+      ...this.config.provider.deployment,
     }
   }
 
@@ -123,7 +124,7 @@ export abstract class BaseService {
     const { deployment, artifact } = configConstants.naming.suffix;
     return `${deploymentName
       .replace(`rg-${deployment}`, artifact)
-      .replace(deployment, artifact)}`
+      .replace(deployment, artifact)}.zip`
   }
 
   /**

--- a/src/services/functionAppService.test.ts
+++ b/src/services/functionAppService.test.ts
@@ -36,6 +36,11 @@ describe("Function App Service", () => {
   const syncTriggersUrl = `${baseUrl}${app.id}/syncfunctiontriggers?api-version=2016-08-01`;
   const listFunctionsUrl = `${baseUrl}${app.id}/functions?api-version=2016-08-01`;
 
+  const appSettings = {
+    setting1: "value1",
+    setting2: "value2",
+  }
+
   beforeAll(() => {
     const axiosMock = new MockAdapter(axios);
 
@@ -65,6 +70,8 @@ describe("Function App Service", () => {
     WebSiteManagementClient.prototype.webApps = {
       get: jest.fn(() => app),
       deleteFunction: jest.fn(),
+      listApplicationSettings: jest.fn(() => Promise.resolve({ properties: { ...appSettings } })),
+      updateApplicationSettings: jest.fn(),
     } as any;
     (FunctionAppService.prototype as any).sendFile = jest.fn();
   });
@@ -155,10 +162,21 @@ describe("Function App Service", () => {
 
     beforeEach(() => {
       FunctionAppService.prototype.get = jest.fn(() => Promise.resolve(expectedSite));
+      (FunctionAppService.prototype as any).sendFile = jest.fn();
       ArmService.prototype.createDeploymentFromConfig = jest.fn(() => Promise.resolve(expectedDeployment));
       ArmService.prototype.createDeploymentFromType = jest.fn(() => Promise.resolve(expectedDeployment));
       ArmService.prototype.deployTemplate = jest.fn(() => Promise.resolve(null));
+      WebSiteManagementClient.prototype.webApps = {
+        get: jest.fn(() => app),
+        deleteFunction: jest.fn(),
+        listApplicationSettings: jest.fn(() => Promise.resolve({ properties: { ...appSettings } })),
+        updateApplicationSettings: jest.fn(),
+      } as any;
     });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    })
 
     it("deploys ARM templates with custom configuration", async () => {
       slsService.provider["armTemplate"] = {};
@@ -181,63 +199,6 @@ describe("Function App Service", () => {
       expect(site).toEqual(expectedSite);
       expect(ArmService.prototype.createDeploymentFromConfig).not.toBeCalled();
       expect(ArmService.prototype.createDeploymentFromType).toBeCalledWith(ArmTemplateType.Consumption);
-      expect(ArmService.prototype.deployTemplate).toBeCalledWith(expectedDeployment);
-    });
-
-    it("deploys ARM template with SAS URL if running from blob URL", async() => {
-      const sasUrl = "sasUrl";
-      AzureBlobStorageService.prototype.generateBlobSasTokenUrl = jest.fn(() => Promise.resolve(sasUrl));
-
-      const newSlsService = MockFactory.createTestService();
-      newSlsService.provider["armTemplate"] = null;
-      newSlsService.provider["deployment"] = {
-        runFromBlobUrl: true,
-      }
-
-      const service = createService(MockFactory.createTestServerless({
-        service: newSlsService,
-      }));
-
-      const site = await service.deploy();
-
-      // Deploy should upload to blob FIRST and then set the SAS URL
-      // as the WEBSITE_RUN_FROM_PACKAGE setting in the template
-      const uploadFileCalls = (AzureBlobStorageService.prototype.uploadFile as any).mock.calls;
-      expect(uploadFileCalls).toHaveLength(1);
-      const call = uploadFileCalls[0];
-      expect(call[0]).toEqual("app.zip");
-      expect(call[1]).toEqual("deployment-artifacts");
-      expect(call[2]).toMatch(/myDeploymentName-t([0-9])+.zip/);
-
-      expect(site).toEqual(expectedSite);
-      expect(ArmService.prototype.createDeploymentFromConfig).not.toBeCalled();
-      expect(ArmService.prototype.createDeploymentFromType).toBeCalledWith(ArmTemplateType.Consumption);
-      // Should set parameter of arm template to include SAS URL
-      expect(ArmService.prototype.deployTemplate).toBeCalledWith({
-        ...expectedDeployment,
-        parameters: {
-          ...expectedDeployment.parameters,
-          functionAppRunFromPackage: sasUrl,
-        }
-      });
-    });
-
-    it("does not generate SAS URL if not configured", async() => {
-      AzureBlobStorageService.prototype.generateBlobSasTokenUrl = jest.fn();
-
-      const newSlsService = MockFactory.createTestService();
-      newSlsService.provider["armTemplate"] = null;
-      newSlsService.provider["deployment"] = {
-        runFromBlobUrl: false,
-      }
-
-      const service = createService(MockFactory.createTestServerless({
-        service: newSlsService,
-      }));
-
-      await service.deploy();
-
-      expect(AzureBlobStorageService.prototype.generateBlobSasTokenUrl).not.toBeCalled();
       expect(ArmService.prototype.deployTemplate).toBeCalledWith(expectedDeployment);
     });
 
@@ -354,4 +315,75 @@ describe("Function App Service", () => {
     const service = createService(sls, options);
     expect(service.getFunctionZipFile()).toEqual("fake.zip")
   });
+
+  it("adds a new function app setting", async () => {
+    const service = createService();
+    const settingName = "TEST_SETTING";
+    const settingValue = "TEST_VALUE"
+    await service.updateFunctionAppSetting(app, settingName, settingValue);
+    expect(WebSiteManagementClient.prototype.webApps.updateApplicationSettings).toBeCalledWith(
+      "myResourceGroup",
+      "Test",
+      {
+        ...appSettings,
+        TEST_SETTING: settingValue
+      }
+    )
+  });
+
+  it("updates an existing function app setting", async () => {
+    const service = createService();
+    const settingName = "setting1";
+    const settingValue = "TEST_VALUE"
+    await service.updateFunctionAppSetting(app, settingName, settingValue);
+    expect(WebSiteManagementClient.prototype.webApps.updateApplicationSettings).toBeCalledWith(
+      "myResourceGroup",
+      "Test",
+      {
+        setting1: settingValue,
+        setting2: appSettings.setting2
+      }
+    );
+  });
+
+  describe("Updating Function App Settings", () => {
+
+    const sasUrl = "sasUrl"
+
+    beforeEach(() => {
+      FunctionAppService.prototype.updateFunctionAppSetting = jest.fn();
+      AzureBlobStorageService.prototype.generateBlobSasTokenUrl = jest.fn(() => Promise.resolve(sasUrl));
+    });
+
+    afterEach(() => {
+      (FunctionAppService.prototype.updateFunctionAppSetting as any).mockRestore();
+    });
+
+    it("updates WEBSITE_RUN_FROM_PACKAGE with SAS URL if configured to run from blob", async () => {
+      const newSlsService = MockFactory.createTestService();
+      newSlsService.provider["deployment"] = {
+        runFromBlobUrl: true,
+      }
+
+      const service = createService(MockFactory.createTestServerless({
+        service: newSlsService,
+      }));
+      await service.uploadFunctions(app);
+      expect(AzureBlobStorageService.prototype.generateBlobSasTokenUrl).toBeCalled();
+      expect(FunctionAppService.prototype.updateFunctionAppSetting).toBeCalledWith(
+        app,
+        "WEBSITE_RUN_FROM_PACKAGE",
+        sasUrl
+      );
+    });
+
+    it("does not generate SAS URL or update WEBSITE_RUN_FROM_PACKAGE if not configured to run from blob", async() => {
+      const service = createService();
+      await service.uploadFunctions(app);
+      expect(AzureBlobStorageService.prototype.generateBlobSasTokenUrl).not.toBeCalled();
+      expect(FunctionAppService.prototype.updateFunctionAppSetting).not.toBeCalled();
+    });
+  });
+
+
 });

--- a/src/services/rollbackService.test.ts
+++ b/src/services/rollbackService.test.ts
@@ -30,7 +30,7 @@ describe("Rollback Service", () => {
   const sasURL = "sasURL";
   const containerName = "deployment-artifacts";
   const artifactName = MockFactory.createTestDeployment().name.replace(
-    configConstants.naming.suffix.deployment, configConstants.naming.suffix.artifact);
+    configConstants.naming.suffix.deployment, configConstants.naming.suffix.artifact) + ".zip";
   const artifactPath = `.serverless${path.sep}${artifactName}`
   const armDeployment: ArmDeployment = { template, parameters };
   const deploymentString = "deployments";
@@ -115,7 +115,7 @@ describe("Rollback Service", () => {
     const deploymentConfig: DeploymentConfig = {
       runFromBlobUrl: true
     }
-    sls["deploy"] = deploymentConfig;
+    sls.service.provider["deployment"] = deploymentConfig;
     const service = createService(sls);
     await service.rollback();
     expect(AzureBlobStorageService.prototype.initialize).toBeCalled();


### PR DESCRIPTION
- [x] Allow configuration to specify whether or not to run from external package
- [x] Set function app setting `WEBSITE_RUN_FROM_PACKAGE` with SAS URL of package from blob storage
- [x] Get deployment configuration from `config.provider`
- [x] Upload to blob storage before deployment if `runFromBlobUrl` is specified
