### PR TITLE
feat: Handle SIGINT and cleanup offline files unless specified to skip

### DIFF
--- a/src/plugins/offline/azureOfflinePlugin.ts
+++ b/src/plugins/offline/azureOfflinePlugin.ts
@@ -30,7 +30,13 @@ export class AzureOfflinePlugin extends AzureBasePlugin {
             usage: "Start Azure Function app - assumes offline build has already occurred",
             lifecycleEvents: [
               "start"
-            ]
+            ],
+            options: {
+              nocleanup: {
+                usage: "Do not clean up offline files after finishing process",
+                shortcut: "n",
+              }
+            }
           },
           build: {
             usage: "Build necessary files for running Azure Function App offline",
@@ -43,6 +49,12 @@ export class AzureOfflinePlugin extends AzureBasePlugin {
             lifecycleEvents: [
               "cleanup"
             ]
+          }
+        },
+        options: {
+          nocleanup: {
+            usage: "Do not clean up offline files after finishing process",
+            shortcut: "n",
           }
         }
       }

--- a/src/services/offlineService.ts
+++ b/src/services/offlineService.ts
@@ -88,6 +88,8 @@ export class OfflineService extends BaseService {
             await this.cleanup();
           }
         } catch {
+          // Swallowing `scandir` error that gets thrown after
+          // trying to remove the same directory twice
         } finally {
           process.exit();
         }

--- a/src/services/offlineService.ts
+++ b/src/services/offlineService.ts
@@ -81,14 +81,16 @@ export class OfflineService extends BaseService {
       const childProcess = spawn(command, spawnArgs, spawnOptions);
 
       process.on("SIGINT", async () => {
-        if (this.getOption("nocleanup")) {
-          this.log("Skipping offline file cleanup...");
+        try {
+          if (this.getOption("nocleanup")) {
+            this.log("Skipping offline file cleanup...");
+          } else {
+            await this.cleanup();
+          }
+        } catch {
+        } finally {
           process.exit();
         }
-        try {
-          await this.cleanup();
-        } catch(e) {}
-        process.exit();
       });
 
       childProcess.on("exit", (code) => {


### PR DESCRIPTION
Cleans up offline files when user interrupts offline process. Allows user to skip cleanup with CLI option.