### PR TITLE
Register missing dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "xml": "^1.0.1"
   },
   "devDependencies": {
+    "@azure/ms-rest-js": "^1.8.7",
     "@babel/runtime": "^7.4.5",
     "@types/jest": "^24.0.13",
     "@types/jsonpath": "^0.2.0",


### PR DESCRIPTION
[`src/test/mockFactory.js` directly relies on `@azure/ms-rest-js`](https://github.com/serverless/serverless-azure-functions/blob/962c619767870ce6a76cbf7a8cdacf15f7d0e658/src/test/mockFactory.ts#L4) while it's not listed in package.json deps, which implies a risk of package not being properly installed in some scenarios.