### PR TITLE
Let Serverless Framework handle error

### DIFF
--- a/src/plugins/login/azureLoginPlugin.test.ts
+++ b/src/plugins/login/azureLoginPlugin.test.ts
@@ -82,19 +82,17 @@ describe("Login Plugin", () => {
     expect(sls.variables["subscriptionId"]).toEqual("azureSubId");
   });
 
-  it("logs an error from authentication and exits process", async () => {
+  it("logs an error from authentication and crashes with it", async () => {
     unsetServicePrincipalEnvVariables();
-    process.exit = jest.fn() as any;
-    const errorMessage = "This is my error message";
+    const error = new Error("This is my error message")
     AzureLoginService.interactiveLogin = jest.fn(() => {
-      throw new Error(errorMessage);
+      throw error;
     });
     const sls = MockFactory.createTestServerless();
-    await invokeLoginHook(false, sls);
+    await expect(invokeLoginHook(false, sls)).rejects.toThrow(error);
     expect(AzureLoginService.interactiveLogin).toBeCalled()
     expect(AzureLoginService.servicePrincipalLogin).not.toBeCalled();
-    expect(sls.cli.log).lastCalledWith(`Error: ${errorMessage}`);
-    expect(process.exit).toBeCalledWith(0);
+    expect(sls.cli.log).lastCalledWith("Error logging into azure");
   });
 
   it("Uses the user specified subscription ID", async () => {

--- a/src/plugins/login/azureLoginPlugin.ts
+++ b/src/plugins/login/azureLoginPlugin.ts
@@ -33,8 +33,7 @@ export class AzureLoginPlugin extends AzureBasePlugin<AzureLoginOptions> {
     }
     catch (e) {
       this.log("Error logging into azure");
-      this.log(`${e}`);
-      process.exit(0);
+      throw e; // Let Serverless Framework communicate the error
     }
   }
 }


### PR DESCRIPTION
I think plugin should not exit process abruptly. Technically it leaves Framework stopped without any possibility to do cleanup (e.g. send some statistics info).

Additionally Framework implements error reporting in user friendly way, so I believe it's better to just let the error surface, and let Framework pick it.