### PR TITLE
fix: Don't require login during packaging. 

### DIFF
--- a/src/plugins/login/loginHooks.ts
+++ b/src/plugins/login/loginHooks.ts
@@ -2,7 +2,6 @@
  * Hooks that require authentication before execution
  */
 export const loginHooks = [
-  "package:initialize",
   "deploy:list:list",
   "deploy:deploy",
   "invoke:invoke",


### PR DESCRIPTION
fix: Don't require login during packaging. 

Logging into the cloud provider takes time and is not necessary before all operations. We currently had the plugin logging into Azure, even when just packaging, which isn't necessary. This prevents login from being called when it is not needed.

AB#801