### PR TITLE
perf: Skip upload to function app if configured to run from blob

### DIFF
--- a/src/services/loginService.test.ts
+++ b/src/services/loginService.test.ts
@@ -22,7 +22,7 @@ describe("Login Service", () => {
     const emptyObj = { subscriptions: [] };
     Object.defineProperty(nodeauth,
       "interactiveLoginWithAuthResponse",
-      { value: jest.fn(_obj => emptyObj) }
+      { value: jest.fn(() => emptyObj) }
     );
 
     await AzureLoginService.login();


### PR DESCRIPTION
Quick fix for not uploading zipped code to Function App if configured to only run from blob, and vice versa