### PR TITLE
fix: Crash deployment if function app zip file doesn't exist

### DIFF
--- a/src/plugins/deploy/azureDeployPlugin.test.ts
+++ b/src/plugins/deploy/azureDeployPlugin.test.ts
@@ -64,4 +64,10 @@ describe("Deploy plugin", () => {
     expect(ResourceService.prototype.listDeployments).toBeCalled();
     expect(sls.cli.log).lastCalledWith(deploymentString);
   });
+	
+  it("crashes deploy if zip file is not found", async () => {
+    FunctionAppService.prototype.getFunctionZipFile = jest.fn(() => "notExisting.zip");
+    await expect(invokeHook(plugin, "deploy:deploy"))
+      .rejects.toThrow(/Function app zip file '.*' does not exist/)
+  });
 });

--- a/src/plugins/deploy/azureDeployPlugin.ts
+++ b/src/plugins/deploy/azureDeployPlugin.ts
@@ -56,8 +56,7 @@ export class AzureDeployPlugin extends AzureBasePlugin<AzureLoginOptions> {
     const functionAppService = new FunctionAppService(this.serverless, this.options);
     const zipFile = functionAppService.getFunctionZipFile();
     if (!fs.existsSync(zipFile)) {
-      this.log(`Function app zip file '${zipFile}' does not exist`);
-      return Promise.resolve();
+      throw new Error(`Function app zip file '${zipFile}' does not exist`);
     }
     await resourceService.deployResourceGroup();
     const functionApp = await functionAppService.deploy();


### PR DESCRIPTION
With `package.individually` the expected function app zip file is not generated in form supported by a plugin.

In such case currently plugin just logs some error message as follows:

```
Function app zip file '/Users/medikoo/Projects/tests/serverless-azure/.serverless/test-azure-0x.zip' does not exist
```

but doesn't exit with an error, which gives a confusing impression.

This PR ensures that such scenario is reported with plugin error