### PR TITLE
fix: Fix bug with invalid token file for interactive login

### DIFF
--- a/src/plugins/login/utils/simpleFileTokenCache.test.ts
+++ b/src/plugins/login/utils/simpleFileTokenCache.test.ts
@@ -81,4 +81,24 @@ describe("Simple File Token Cache", () => {
     expect(writeFileSpy).toBeCalledWith(tokenFilePath, JSON.stringify(expected));
     writeFileSpy.mockRestore();
   });
+
+  it("Doesn't fail if unable to parse JSON from file", () => {
+    mockFs({
+      "slsTokenCache.json": JSON.stringify(""),
+    });
+
+    const writeFileSpy = jest.spyOn(fs, "writeFileSync");
+    const testFileCache = new SimpleFileTokenCache(tokenFilePath);
+    const testSubs = MockFactory.createTestSubscriptions();
+
+    testFileCache.addSubs(testSubs);
+
+    const expected = {
+      entries: [],
+      subscriptions: testSubs,
+    };
+
+    expect(writeFileSpy).toBeCalledWith(tokenFilePath, JSON.stringify(expected));
+    writeFileSpy.mockRestore();
+  });
 });

--- a/src/plugins/login/utils/simpleFileTokenCache.ts
+++ b/src/plugins/login/utils/simpleFileTokenCache.ts
@@ -64,11 +64,11 @@ export class SimpleFileTokenCache implements adal.TokenCache {
   }
 
   public isEmpty() {
-    return this.entries.length === 0;
+    return !this.entries || this.entries.length === 0;
   }
 
   public first() {
-    return this.entries[0];
+    return (this.entries && this.entries.length) ? this.entries[0] : null;
   }
 
   public listSubscriptions() {
@@ -76,14 +76,19 @@ export class SimpleFileTokenCache implements adal.TokenCache {
   }
 
   private load() {
-    if (fs.existsSync(this.tokenPath)) {
-      let savedCache = JSON.parse(fs.readFileSync(this.tokenPath).toString());
-      this.entries = savedCache.entries;
-      this.entries.map(t => t.expiresOn = new Date(t.expiresOn))
-      this.subscriptions = savedCache.subscriptions;
-    } else {
+    if (!fs.existsSync(this.tokenPath)) {
       this.save();
+      return;
     }
+    const savedCache = JSON.parse(fs.readFileSync(this.tokenPath).toString());
+
+    if (!savedCache || !savedCache.entries) {
+      this.save();
+      return;
+    }
+    this.entries = savedCache.entries;
+    this.entries.map(t => t.expiresOn = new Date(t.expiresOn))
+    this.subscriptions = savedCache.subscriptions;
   }
 
   public save() {


### PR DESCRIPTION
This issue surfaced when trying to do interactive login. It seems like the file was created, but was either invalid or empty. This adds a couple checks to make sure the JSON is parsed correctly and that all the data exists.

Resolves AB#838