### PR TITLE
fix: Check for valid entries in token cache remove and find

### DIFF
--- a/src/plugins/login/utils/simpleFileTokenCache.test.ts
+++ b/src/plugins/login/utils/simpleFileTokenCache.test.ts
@@ -82,7 +82,7 @@ describe("Simple File Token Cache", () => {
     writeFileSpy.mockRestore();
   });
 
-  it("Doesn't fail if unable to parse JSON from file", () => {
+  it("Doesn't fail adding subs if unable to parse JSON from file", () => {
     mockFs({
       "slsTokenCache.json": JSON.stringify(""),
     });
@@ -100,5 +100,43 @@ describe("Simple File Token Cache", () => {
 
     expect(writeFileSpy).toBeCalledWith(tokenFilePath, JSON.stringify(expected));
     writeFileSpy.mockRestore();
+  });
+
+  it("Doesn't fail removing entries if unable to parse JSON from file", () => {
+    mockFs({
+      "slsTokenCache.json": JSON.stringify(""),
+    });
+
+    const writeFileSpy = jest.spyOn(fs, "writeFileSync");
+    const testFileCache = new SimpleFileTokenCache(tokenFilePath);
+    const testSubs = MockFactory.createTestSubscriptions();
+    const testEntries = MockFactory.createTestTokenCacheEntries();
+
+    testFileCache.addSubs(testSubs);
+    testFileCache.remove(testEntries)
+
+    const expected = {
+      entries: [],
+      subscriptions: testSubs,
+    };
+
+    expect(writeFileSpy).toBeCalledWith(tokenFilePath, JSON.stringify(expected));
+    writeFileSpy.mockRestore();
+  });
+
+  it("Doesn't fail find if unable to parse JSON from file", () => {
+    mockFs({
+      "slsTokenCache.json": JSON.stringify(""),
+    });
+
+    const testFileCache = new SimpleFileTokenCache(tokenFilePath);
+    const testSubs = MockFactory.createTestSubscriptions();
+
+    testFileCache.addSubs(testSubs);
+    const cb = jest.fn();
+    const result = testFileCache.find({key: "value"}, cb);
+
+    expect(cb).toBeCalledWith(null, result);
+    expect(result).toEqual([]);
   });
 });

--- a/src/plugins/login/utils/simpleFileTokenCache.ts
+++ b/src/plugins/login/utils/simpleFileTokenCache.ts
@@ -23,9 +23,13 @@ export class SimpleFileTokenCache implements adal.TokenCache {
   }
 
   public remove(entries: any[], callback?: (err?: Error, result?: null) => void) {
-    this.entries = this.entries.filter(e => {
-      return !Object.keys(entries[0]).every(key => e[key] === entries[0][key]);
-    });
+    this.entries = (this.entries)
+      ?
+      this.entries.filter(e => {
+        return !Object.keys(entries[0]).every(key => e[key] === entries[0][key]);
+      })
+      :
+      [];
     this.save();
     if (callback) {
       callback();
@@ -33,9 +37,13 @@ export class SimpleFileTokenCache implements adal.TokenCache {
   }
 
   public find(query: any, callback: (err?: Error, result?: any[]) => void) {
-    let result = this.entries.filter(e => {
-      return Object.keys(query).every(key => e[key] === query[key]);
-    });
+    let result = (this.entries)
+      ?
+      this.entries.filter(e => {
+        return Object.keys(query).every(key => e[key] === query[key]);
+      })
+      :
+      [];
     callback(null, result);
     return result;
   }


### PR DESCRIPTION
Fails if user previously started interactive login process without finishing because it writes an invalid JSON file. This checks to make sure the parsed JSON is valid and that entries exists