### PR TITLE
feat: Add `hooks` type to base plugin, document plugin options for CLI help

### DIFF
--- a/src/models/serverless.ts
+++ b/src/models/serverless.ts
@@ -88,6 +88,10 @@ export interface ServerlessCommand {
   commands?: ServerlessCommandMap;
 }
 
+export interface ServerlessHookMap {
+  [eventName: string]: Promise<any>;
+}
+
 export interface ServerlessCommandMap {
   [command: string]: ServerlessCommand;
 }

--- a/src/plugins/apim/azureApimFunctionPlugin.ts
+++ b/src/plugins/apim/azureApimFunctionPlugin.ts
@@ -3,7 +3,6 @@ import { ApimService } from "../../services/apimService";
 import { AzureBasePlugin } from "../azureBasePlugin";
 
 export class AzureApimFunctionPlugin extends AzureBasePlugin {
-  public hooks: { [eventName: string]: Promise<any> };
 
   public constructor(serverless: Serverless, options: Serverless.Options) {
     super(serverless, options);

--- a/src/plugins/apim/azureApimServicePlugin.ts
+++ b/src/plugins/apim/azureApimServicePlugin.ts
@@ -3,7 +3,6 @@ import { ApimService } from "../../services/apimService";
 import { AzureBasePlugin } from "../azureBasePlugin";
 
 export class AzureApimServicePlugin extends AzureBasePlugin {
-  public hooks: { [eventName: string]: Promise<any> };
 
   public constructor(serverless: Serverless, options: Serverless.Options) {
     super(serverless, options);

--- a/src/plugins/azureBasePlugin.ts
+++ b/src/plugins/azureBasePlugin.ts
@@ -1,8 +1,13 @@
 import { Guard } from "../shared/guard";
 import Serverless from "serverless";
 import { Utils } from "../shared/utils";
+import { ServerlessCommandMap, ServerlessHookMap } from "../models/serverless";
 
 export abstract class AzureBasePlugin<TOptions=Serverless.Options> {
+
+  public hooks: ServerlessHookMap
+  protected commands: ServerlessCommandMap;
+
   public constructor(
     protected serverless: Serverless,
     protected options: TOptions,

--- a/src/plugins/deploy/azureDeployPlugin.ts
+++ b/src/plugins/deploy/azureDeployPlugin.ts
@@ -6,7 +6,6 @@ import { ResourceService } from "../../services/resourceService";
 import { AzureBasePlugin } from "../azureBasePlugin";
 
 export class AzureDeployPlugin extends AzureBasePlugin<AzureLoginOptions> {
-  public hooks: { [eventName: string]: Promise<any> };
   public commands: any;
 
   public constructor(serverless: Serverless, options: AzureLoginOptions) {
@@ -25,12 +24,38 @@ export class AzureDeployPlugin extends AzureBasePlugin<AzureLoginOptions> {
             lifecycleEvents: [
               "list"
             ]
+          },
+          options: {
+            resourceGroup: {
+              usage: "Resource group for the service",
+              shortcut: "g",
+            },
+            stage: {
+              usage: "Stage of service",
+              shortcut: "s"
+            },
+            region: {
+              usage: "Region of service",
+              shortcut: "r"
+            },
+            subscriptionId: {
+              usage: "Sets the Azure subscription ID",
+              shortcut: "i",
+            },
           }
         },
         options: {
           resourceGroup: {
             usage: "Resource group for the service",
             shortcut: "g",
+          },
+          stage: {
+            usage: "Stage of service",
+            shortcut: "s"
+          },
+          region: {
+            usage: "Region of service",
+            shortcut: "r"
           },
           subscriptionId: {
             usage: "Sets the Azure subscription ID",

--- a/src/plugins/func/azureFuncPlugin.ts
+++ b/src/plugins/func/azureFuncPlugin.ts
@@ -3,8 +3,6 @@ import { FuncService } from "../../services/funcService";
 import { AzureBasePlugin } from "../azureBasePlugin";
 
 export class AzureFuncPlugin extends AzureBasePlugin {
-  public hooks: { [eventName: string]: Promise<any> };
-  public commands: any;
   private service: FuncService;
 
   public constructor(serverless: Serverless, options: Serverless.Options) {

--- a/src/plugins/invoke/azureInvokePlugin.ts
+++ b/src/plugins/invoke/azureInvokePlugin.ts
@@ -1,14 +1,13 @@
+import fs from "fs";
 import { isAbsolute, join } from "path";
 import Serverless from "serverless";
 import { InvokeService } from "../../services/invokeService";
-import fs from "fs";
-import { ServerlessCommandMap } from "../../models/serverless";
 import { AzureBasePlugin } from "../azureBasePlugin";
 
 export class AzureInvokePlugin extends AzureBasePlugin {
-  public hooks: { [eventName: string]: Promise<any> };
-  private commands: ServerlessCommandMap;
+
   private invokeService: InvokeService;
+
   public constructor(serverless: Serverless, options: Serverless.Options) {
     super(serverless, options);
     const path = this.options["path"];
@@ -31,6 +30,22 @@ export class AzureInvokePlugin extends AzureBasePlugin {
         usage: "Invoke command",
         lifecycleEvents: ["invoke"],
         options: {
+          resourceGroup: {
+            usage: "Resource group for the service",
+            shortcut: "g",
+          },
+          stage: {
+            usage: "Stage of service",
+            shortcut: "s"
+          },
+          region: {
+            usage: "Region of service",
+            shortcut: "r"
+          },
+          subscriptionId: {
+            usage: "Sets the Azure subscription ID",
+            shortcut: "i",
+          },
           function: {
             usage: "Function to call",
             shortcut: "f",

--- a/src/plugins/login/azureLoginPlugin.ts
+++ b/src/plugins/login/azureLoginPlugin.ts
@@ -4,7 +4,6 @@ import { AzureBasePlugin } from "../azureBasePlugin";
 import { loginHooks } from "./loginHooks";
 
 export class AzureLoginPlugin extends AzureBasePlugin<AzureLoginOptions> {
-  public hooks: { [eventName: string]: Promise<any> };
 
   public constructor(serverless: Serverless, options: AzureLoginOptions) {
     super(serverless, options);

--- a/src/plugins/logs/azureLogsPlugin.ts
+++ b/src/plugins/logs/azureLogsPlugin.ts
@@ -3,7 +3,6 @@ import AzureProvider from "../../provider/azureProvider";
 import { AzureBasePlugin } from "../azureBasePlugin";
 
 export class AzureLogsPlugin extends AzureBasePlugin {
-  public hooks: { [eventName: string]: Promise<any> };
 
   private provider: AzureProvider;
 

--- a/src/plugins/offline/azureOfflinePlugin.ts
+++ b/src/plugins/offline/azureOfflinePlugin.ts
@@ -3,8 +3,6 @@ import { OfflineService } from "../../services/offlineService";
 import { AzureBasePlugin } from "../azureBasePlugin";
 
 export class AzureOfflinePlugin extends AzureBasePlugin {
-  public hooks: { [eventName: string]: Promise<any> };
-  public commands: any;
   private offlineService: OfflineService;
 
   public constructor(serverless: Serverless, options: Serverless.Options) {

--- a/src/plugins/package/azurePackagePlugin.ts
+++ b/src/plugins/package/azurePackagePlugin.ts
@@ -8,7 +8,6 @@ export class AzurePackagePlugin extends AzureBasePlugin {
   private bindingsCreated: boolean = false;
   private packageService: PackageService;
   public provider: AzureProvider;
-  public hooks: { [eventName: string]: Promise<any> };
 
   public constructor(serverless: Serverless, options: Serverless.Options) {
     super(serverless, options);

--- a/src/plugins/remove/azureRemovePlugin.ts
+++ b/src/plugins/remove/azureRemovePlugin.ts
@@ -3,10 +3,37 @@ import { ResourceService } from "../../services/resourceService";
 import { AzureBasePlugin } from "../azureBasePlugin";
 
 export class AzureRemovePlugin extends AzureBasePlugin {
-  public hooks: { [eventName: string]: Promise<any> };
 
   public constructor(serverless: Serverless, options: Serverless.Options) {
     super(serverless, options);
+
+    this.commands = {
+      remove: {
+        usage: "Remove service resource group (USE WITH CAUTION)",
+        lifecycleEvents: [
+          "remove"
+        ],
+        options: {
+          resourceGroup: {
+            usage: "Resource group for the service",
+            shortcut: "g",
+          },
+          stage: {
+            usage: "Stage of service",
+            shortcut: "s"
+          },
+          region: {
+            usage: "Region of service",
+            shortcut: "r"
+          },
+          subscriptionId: {
+            usage: "Sets the Azure subscription ID",
+            shortcut: "i",
+          },
+        }
+      }
+    }
+
     this.hooks = {
       "remove:remove": this.remove.bind(this)
     };

--- a/src/plugins/rollback/azureRollbackPlugin.ts
+++ b/src/plugins/rollback/azureRollbackPlugin.ts
@@ -6,10 +6,41 @@ import { AzureBasePlugin } from "../azureBasePlugin";
  * Plugin for rolling back Function App Service to previous deployment
  */
 export class AzureRollbackPlugin extends AzureBasePlugin {
-  public hooks: { [eventName: string]: Promise<any> };
 
   public constructor(serverless: Serverless, options: Serverless.Options) {
     super(serverless, options);
+
+    this.commands = {
+      rollback: {
+        usage: "Rollback command",
+        lifecycleEvents: [
+          "rollback"
+        ],
+        options: {
+          timestamp: {
+            usage: "Timestamp of previous deployment",
+            shortcut: "t",
+          },
+          resourceGroup: {
+            usage: "Resource group for the service",
+            shortcut: "g",
+          },
+          stage: {
+            usage: "Stage of service",
+            shortcut: "s"
+          },
+          region: {
+            usage: "Region of service",
+            shortcut: "r"
+          },
+          subscriptionId: {
+            usage: "Sets the Azure subscription ID",
+            shortcut: "i",
+          },
+        }
+      }
+    }
+
     this.hooks = {
       "rollback:rollback": this.rollback.bind(this)
     };


### PR DESCRIPTION
- [x] Added `commands` to all plugins
- [x] Added `resourceGroup`, `stage`, `region` and `subscriptionId` to all CLI commands that need to log into Azure
- [x] Refactored `hooks` and `commands` to exist at the `BasePlugin` level
- [x] Added type `ServerlessHookMap`

Resolves AB#802 and AB#795