### PR TITLE
fix: exclude test files

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -58,5 +58,9 @@
   "include": [
     "./src",
     "./src/**/*.json"
+  ],
+  "exclude": [
+    "**/test",
+    "**/*.test.ts"
   ]
 }


### PR DESCRIPTION
Excluding all test files from ./lib/. These will no longer be included in the NPM package.

AB#804