### PR TITLE
fix: Don't skip deploy if previous equivalent deployment failed

### DIFF
--- a/src/models/armTemplates.ts
+++ b/src/models/armTemplates.ts
@@ -9,8 +9,8 @@ export interface ArmResourceTemplateGenerator {
 }
 
 export enum ArmTemplateProvisioningState {
-  Failed = "Failed",
-  Succeeded = "Succeeded",
+  FAILED = "Failed",
+  SUCCEEDED = "Succeeded",
 }
 
 /**

--- a/src/models/armTemplates.ts
+++ b/src/models/armTemplates.ts
@@ -8,6 +8,11 @@ export interface ArmResourceTemplateGenerator {
   getParameters(config: ServerlessAzureConfig): any;
 }
 
+export enum ArmTemplateProvisioningState {
+  Failed = "Failed",
+  Succeeded = "Succeeded",
+}
+
 /**
  * The well-known serverless Azure template types
  */

--- a/src/services/armService.test.ts
+++ b/src/services/armService.test.ts
@@ -174,7 +174,7 @@ describe("Arm Service", () => {
         ...deployments[0],
         properties: {
           ...deployments[0].properties,
-          provisioningState: ArmTemplateProvisioningState.Failed
+          provisioningState: ArmTemplateProvisioningState.FAILED
         }
       }
       deployments[0] = failedDeployment;

--- a/src/services/resourceService.ts
+++ b/src/services/resourceService.ts
@@ -41,7 +41,7 @@ export class ResourceService extends BaseService {
    */
   public async getLastDeploymentTemplate(): Promise<ArmDeployment> {
     const deployment = await this.getLastDeployment();
-    if (!deployment || deployment.properties.provisioningState !== ArmTemplateProvisioningState.Succeeded) {
+    if (!deployment || deployment.properties.provisioningState !== ArmTemplateProvisioningState.SUCCEEDED) {
       return;
     }
     const { parameters } = deployment.properties;

--- a/src/services/resourceService.ts
+++ b/src/services/resourceService.ts
@@ -3,7 +3,7 @@ import { ResourceManagementClient } from "@azure/arm-resources";
 import { BaseService } from "./baseService";
 import { Utils } from "../shared/utils";
 import { AzureNamingService } from "./namingService";
-import { ArmDeployment } from "../models/armTemplates";
+import { ArmDeployment, ArmTemplateProvisioningState } from "../models/armTemplates";
 import { DeploymentExtended } from "@azure/arm-resources/esm/models";
 
 export class ResourceService extends BaseService {
@@ -41,7 +41,7 @@ export class ResourceService extends BaseService {
    */
   public async getLastDeploymentTemplate(): Promise<ArmDeployment> {
     const deployment = await this.getLastDeployment();
-    if (!deployment) {
+    if (!deployment || deployment.properties.provisioningState !== ArmTemplateProvisioningState.Succeeded) {
       return;
     }
     const { parameters } = deployment.properties;

--- a/src/test/mockFactory.ts
+++ b/src/test/mockFactory.ts
@@ -193,7 +193,7 @@ export class MockFactory {
       properties: {
         timestamp: new Date(2019, 1, 1, 0, 0, second),
         parameters: MockFactory.createTestParameters(),
-        provisioningState: ArmTemplateProvisioningState.Succeeded
+        provisioningState: ArmTemplateProvisioningState.SUCCEEDED
       }
     }
   }

--- a/src/test/mockFactory.ts
+++ b/src/test/mockFactory.ts
@@ -12,7 +12,7 @@ import Service from "serverless/classes/Service";
 import Utils from "serverless/classes/Utils";
 import PluginManager from "serverless/lib/classes/PluginManager";
 import { ApiCorsPolicy, ApiManagementConfig } from "../models/apiManagement";
-import { ArmDeployment, ArmResourceTemplate } from "../models/armTemplates";
+import { ArmDeployment, ArmResourceTemplate, ArmTemplateProvisioningState } from "../models/armTemplates";
 import { ServicePrincipalEnvVariables } from "../models/azureProvider";
 import { Logger } from "../models/generic";
 import { ServerlessAzureConfig, ServerlessAzureProvider, ServerlessAzureFunctionConfig } from "../models/serverless";
@@ -193,6 +193,7 @@ export class MockFactory {
       properties: {
         timestamp: new Date(2019, 1, 1, 0, 0, second),
         parameters: MockFactory.createTestParameters(),
+        provisioningState: ArmTemplateProvisioningState.Succeeded
       }
     }
   }


### PR DESCRIPTION
Currently, if a deployment fails and the next deployment's template & parameters are identical, the deployment will be skipped. This adds the check to see if the deployment was successful.

Resolves AB#852