### PR TITLE
docs: Add contribution guidelines

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Create a report to help us improve
+---
+
+<!--
+1. If you have a question and not a bug report please ask first at http://forum.serverless.com
+2. Please check if an issue already exists. This bug may have already been documented
+3. Check out and follow our Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
+4. Fill out the whole template so we have a good overview on the issue
+5. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the Issue
+6. Please follow the template, otherwise we'll have to ask you to update it
+-->
+
+# This is a Bug Report
+
+## Description
+
+- What went wrong?
+- What did you expect should have happened?
+- What was the config you used?
+- What stacktrace or error message from your provider did you see?
+
+Similar or dependent issues:
+
+- #12345
+
+## Additional Data
+
+- **_Serverless Framework Version you're using_**:
+- **_Operating System_**:
+- **_Stack Trace_**:
+- **_Provider Error messages_**:

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,12 +4,11 @@ about: Create a report to help us improve
 ---
 
 <!--
-1. If you have a question and not a bug report please ask first at http://forum.serverless.com
-2. Please check if an issue already exists. This bug may have already been documented
-3. Check out and follow our Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
-4. Fill out the whole template so we have a good overview on the issue
-5. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the Issue
-6. Please follow the template, otherwise we'll have to ask you to update it
+1. Please check if an issue already exists. This bug may have already been documented
+2. Check out and follow our Guidelines: https://github.com/serverless/serverless-azure-functions/CONTRIBUTING.md
+3. Fill out the whole template so we have a good overview on the issue
+4. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the Issue
+5. Please follow the template, otherwise we'll have to ask you to update it
 -->
 
 # This is a Bug Report
@@ -28,6 +27,7 @@ Similar or dependent issues:
 ## Additional Data
 
 - **_Serverless Framework Version you're using_**:
+- **_Serverless Azure Plugin Version you're using_**:
 - **_Operating System_**:
 - **_Stack Trace_**:
 - **_Provider Error messages_**:

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -27,6 +27,7 @@ Similar or dependent issues:
 ## Additional Data
 
 - **_Serverless Framework Version you're using_**:
+- **_Serverless CLI Version you're using_**:
 - **_Serverless Azure Plugin Version you're using_**:
 - **_Operating System_**:
 - **_Stack Trace_**:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,24 @@
+---
+name: Feature request
+about: Suggest an idea for serverless framework
+---
+
+<!--
+1. If you have a question and not a feature request please ask first at http://forum.serverless.com
+2. Please check if an issue already exists. This feature may have already been requested
+3. Check out and follow our Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
+4. Fill out the whole template so we have a good overview on the issue
+5. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the Issue
+6. Please follow the template, otherwise we'll have to ask you to update it
+-->
+
+# This is a Feature Proposal
+
+## Description
+
+- What is the use case that should be solved. The more detail you describe this in the easier it is to understand for us.
+- If there is additional config how would it look
+
+Similar or dependent issues:
+
+- #12345

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,12 +4,11 @@ about: Suggest an idea for serverless framework
 ---
 
 <!--
-1. If you have a question and not a feature request please ask first at http://forum.serverless.com
-2. Please check if an issue already exists. This feature may have already been requested
-3. Check out and follow our Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
-4. Fill out the whole template so we have a good overview on the issue
-5. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the Issue
-6. Please follow the template, otherwise we'll have to ask you to update it
+1. Please check if an issue already exists. This feature may have already been requested
+2. Check out and follow our Guidelines: https://github.com/serverless/serverless-azure-functions/CONTRIBUTING.md
+3. Fill out the whole template so we have a good overview on the issue
+4. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the Issue
+5. Please follow the template, otherwise we'll have to ask you to update it
 -->
 
 # This is a Feature Proposal

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,54 @@
+<!--
+1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
+2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
+3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
+-->
+
+## What did you implement:
+
+Closes #XXXXX
+
+<!--
+Briefly describe the feature if no issue exists for this PR
+-->
+
+## How did you implement it:
+
+<!--
+If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
+-->
+
+## How can we verify it:
+
+<!--
+Add any applicable config, commands, screenshots or other resources
+to make it easy for us to verify this works. The easier you make it for us
+to review a PR, the faster we can review and merge it.
+
+Examples:
+* serverless.yml - Fully functioning to easily deploy changes
+* Screenshots - Showing the difference between your output and the master
+* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
+* Other - Anything else that comes to mind to help us evaluate
+-->
+
+## Todos:
+
+_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_
+
+- [ ] Write tests and confirm existing functionality is not broken.  
+       **Validate via `npm test`**
+- [ ] Write documentation
+- [ ] Ensure there are no lint errors.  
+       **Validate via `npm run lint-updated`**  
+       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
+- [ ] Ensure introduced changes match Prettier formatting.  
+       **Validate via `npm run prettier-check-updated`**  
+       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
+- [ ] Make sure code coverage hasn't dropped
+- [ ] Provide verification config / commands / resources
+- [ ] Enable "Allow edits from maintainers" for this PR
+- [ ] Update the messages below
+
+**_Is this ready for review?:_** NO  
+**_Is it a breaking change?:_** NO

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,7 +34,7 @@ Examples:
 
 ## Todos:
 
-_**Note: Run `npm run test-ci` to run all validation checks on proposed changes**_
+_**Note: Run `npm run test:ci` to run all validation checks on proposed changes**_
 
 - [ ] Write tests and confirm existing functionality is not broken.  
        **Validate via `npm test`**

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -40,11 +40,8 @@ _**Note: Run `npm run test-ci` to run all validation checks on proposed changes*
        **Validate via `npm test`**
 - [ ] Write documentation
 - [ ] Ensure there are no lint errors.  
-       **Validate via `npm run lint-updated`**  
+       **Validate via `npm run lint`**  
        _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
-- [ ] Ensure introduced changes match Prettier formatting.  
-       **Validate via `npm run prettier-check-updated`**  
-       _Note: All reported issues can be automatically fixed by running `npm run prettify-updated`_
 - [ ] Make sure code coverage hasn't dropped
 - [ ] Provide verification config / commands / resources
 - [ ] Enable "Allow edits from maintainers" for this PR

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,5 +1,5 @@
 <!--
-1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md
+1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless-azure-functions/CONTRIBUTING.md
 2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
 3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
 -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,12 +32,69 @@ The easiest thing you can do to help us move forward and make an impact on our p
 
 You can do that by replying to [issues on Github](https://github.com/serverless/serverless-azure-functions/issues), chatting with other community members in [our Chat](http://chat.serverless.com) or helping with questions in [our Forum](http://forum.serverless.com).
 
+### Commit Message Format
+
+Each commit message consists of a **header**, a **body** and a **footer**.
+
+```text
+<type>: <short description>
+<BLANK LINE>
+<body>
+<BLANK LINE>
+<footer>
+```
+
+### Header
+
+#### Type
+
+Must be one of the following:
+
+* **build**: Changes that affect the build system or external dependencies
+* **ci**: Changes to our CI configuration files and scripts
+* **docs**: Documentation only changes
+* **feat**: A new feature
+* **fix**: A bug fix
+* **perf**: A code change that improves performance
+* **refactor**: A code change that neither fixes a bug nor adds a feature
+* **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
+* **test**: Adding missing tests or correcting existing tests
+
+#### Short Description
+
+Contains a succinct description of the change:
+
+* use the imperative, present tense: "change" not "changed" nor "changes"
+* don't capitalize the first letter
+* no dot (.) at the end
+
+### Body
+
+Just as in the **short description**, use the imperative, present tense: "change" not "changed" nor "changes".
+The body should include the motivation for the change and contrast this with previous behavior.
+
+### Footer
+
+The footer should contain any information about **breaking changes** and is also the place to
+reference Azure DevOps user stories/tasks or GitHub issues that this commit **closes**.
+
+### Commit Message Example
+
+```text
+fix: add debouncing to asset scroller to correct browser scroll position
+
+There is no debouncing when we store the asset container's scroll position.
+This results in erratic, jumpy scrolling and a poor user experience. Improve
+stability and usability with debouncing.
+
+AB#17056
+```
 
 ---
 
 # Code Style
 
-We aim for clean, consistent code style. We're using ESlint to check for codestyle issues using the Airbnb preset.
+We aim for clean, consistent code style. We're using ESlint to check for codestyle issues.
 
 ## Verifying linting style
 
@@ -55,7 +112,7 @@ To help reduce the effort of creating contributions with this style, an [.editor
 
 # Testing
 
-We aim for a (near) 100% test coverage, so make sure your tests cover as much of your code as possible.
+We aim for a (near) 80% test coverage, so make sure your tests cover as much of your code as possible.
 
 ## Test coverage
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,6 +59,7 @@ Must be one of the following:
 * **refactor**: A code change that neither fixes a bug nor adds a feature
 * **style**: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
 * **test**: Adding missing tests or correcting existing tests
+* **chore**: Updating dependencies
 
 #### Short Description
 
@@ -87,7 +88,7 @@ There is no debouncing when we store the asset container's scroll position.
 This results in erratic, jumpy scrolling and a poor user experience. Improve
 stability and usability with debouncing.
 
-AB#17056
+closes #123
 ```
 
 ---
@@ -112,7 +113,7 @@ To help reduce the effort of creating contributions with this style, an [.editor
 
 # Testing
 
-We aim for a (near) 80% test coverage, so make sure your tests cover as much of your code as possible.
+We aim for a (near) 75% test coverage, so make sure your tests cover as much of your code as possible.
 
 ## Test coverage
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,76 @@
+# Contributing Guidelines
+
+Welcome, and thanks in advance for your help! Please follow these simple guidelines :+1:
+
+# How to contribute to the Serverless Azure Plugin
+
+## When you propose a new feature or bug fix
+
+**Note:** Please make sure to write an issue first and get enough feedback before jumping into a Pull Request!
+
+- Please make sure there is an open issue discussing your contribution
+- If there isn't, please open an issue so we can talk about it before you invest time into the implementation
+- When creating an issue or pull request, follow the template that GitHub shows so that we have enough information about your request
+
+## When you want to work on an existing issue
+
+**Note:** Please write a quick comment in the corresponding issue and ask if the feature is still relevant and that you want to jump into the implementation.
+
+We will do our best to respond/review/merge your PR according to priority. We hope that you stay engaged with us during this period to insure QA. Please note that the PR will be closed if there hasn't been any activity for a long time (~ 30 days) to keep us focused and keep the repo clean.
+
+## Reviewing Pull Requests
+
+Another really useful way to contribute to Serverless is to review other peoples Pull Requests. Having feedback from multiple people is really helpful and reduces the overall time to make a final decision about the Pull Request.
+
+## Writing / improving documentation
+
+Our documentation lives on GitHub in the [docs](docs) directory. Do you see a typo or other ways to improve it? Feel free to edit it and submit a Pull Request!
+
+## Providing support
+
+The easiest thing you can do to help us move forward and make an impact on our progress is to simply provide support to other people having difficulties with their Serverless projects.
+
+You can do that by replying to [issues on Github](https://github.com/serverless/serverless-azure-functions/issues), chatting with other community members in [our Chat](http://chat.serverless.com) or helping with questions in [our Forum](http://forum.serverless.com).
+
+
+---
+
+# Code Style
+
+We aim for clean, consistent code style. We're using ESlint to check for codestyle issues using the Airbnb preset.
+
+## Verifying linting style
+
+```
+npm run lint
+```
+
+## Fixing lint issues
+
+```
+npm run lint:fix
+```
+
+To help reduce the effort of creating contributions with this style, an [.editorconfig file](http://editorconfig.org/) is provided that your editor may use to override any conflicting global defaults and automate a subset of the style settings.
+
+# Testing
+
+We aim for a (near) 100% test coverage, so make sure your tests cover as much of your code as possible.
+
+## Test coverage
+
+During development, you can easily check coverage by running `npm test`.
+
+Please follow these Testing guidelines when writing your unit tests:
+
+- Include a top-level `describe('ClassName')` block, with the name of the class you are testing
+- Inside that top-level `describe()` block, create another `describe('#methodOne()')` block for each class method you might create or modify
+- For each method, include an `it('should do something')` test case for each logical edge case in your changes
+- As you write tests, check the code coverage and make sure all lines of code are covered. If not, just add more test cases until everything is covered
+- For reference and inspiration, please check our `tests` directory
+
+---
+
+Thanks again for being a contributor to the Serverless Community :tada:!
+
+Thanks!

--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ The getting started walkthrough illustrates the interactive login experience, wh
 
 Please create issues in this repo for any problems or questions you find. Before sending a PR for any major changes, please create an issue to discuss.
 
-We're still in the process of getting everying running 100%, but please refer to the [Serverless contributing guidlines](https://github.com/serverless/serverless/blob/master/CONTRIBUTING.md) for information on how to contribute and code of conduct.
+We're still in the process of getting everying running 100%, but please refer to the [Serverless contributing guidlines](CONTRIBUTING.md) for information on how to contribute and code of conduct.
 
 #### Local dev
 


### PR DESCRIPTION
Add contribution guidelines and templates for pull requests, bug reports, and feature requests for the  plugin repo. Most of the templates and guides are taken from the core Serverless repo to best match the process put forth there, with minor adjustments to reflect the setup of this repo 

AB#805