### PR TITLE
fix: Remove VSCode project-level settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,0 @@
-{
-  "eslint.options": {
-    "configFile": "./.eslintrc.json"
-  },
-  "eslint.validate": [
-    "javascript",
-    "typescript"
-  ]
-}


### PR DESCRIPTION
I believe specific editor settings should not be committed into project.

In my case those settings collide with how I work with VS Code. I have some global settings, which I need to tweak in context of this project, still that's not possible without editing this file (as that in turn affects `git status`, which makes working with project repository cumbersome).