### PR TITLE
fix: Throw error if user tries to specify function for deployment

### DIFF
--- a/src/plugins/deploy/azureDeployPlugin.test.ts
+++ b/src/plugins/deploy/azureDeployPlugin.test.ts
@@ -57,6 +57,13 @@ describe("Deploy plugin", () => {
     expect(uploadFunctions).toBeCalledWith(functionAppStub);
   });
 
+  it("Crashes deploy if function is specified", async () => {
+    plugin = new AzureDeployPlugin(sls, { function: "myFunction" } as any);
+    await expect(invokeHook(plugin, "deploy:deploy"))
+      .rejects.toThrow("The Azure Functions plugin does not currently support deployments of individual functions. " +
+        "Azure Functions are zipped up as a package and deployed together as a unit");
+  });
+
   it("lists deployments", async () => {
     const deploymentString = "deployments";
     ResourceService.prototype.listDeployments = jest.fn(() => Promise.resolve(deploymentString));
@@ -64,7 +71,14 @@ describe("Deploy plugin", () => {
     expect(ResourceService.prototype.listDeployments).toBeCalled();
     expect(sls.cli.log).lastCalledWith(deploymentString);
   });
-	
+
+  it("Crashes deploy list if function is specified", async () => {
+    plugin = new AzureDeployPlugin(sls, { function: "myFunction" } as any);
+    await expect(invokeHook(plugin, "deploy:list:list"))
+      .rejects.toThrow("The Azure Functions plugin does not currently support deployments of individual functions. " +
+        "Azure Functions are zipped up as a package and deployed together as a unit");
+  });
+
   it("crashes deploy if zip file is not found", async () => {
     FunctionAppService.prototype.getFunctionZipFile = jest.fn(() => "notExisting.zip");
     await expect(invokeHook(plugin, "deploy:deploy"))

--- a/src/plugins/deploy/azureDeployPlugin.ts
+++ b/src/plugins/deploy/azureDeployPlugin.ts
@@ -42,6 +42,10 @@ export class AzureDeployPlugin extends AzureBasePlugin<AzureLoginOptions> {
               usage: "Sets the Azure subscription ID",
               shortcut: "i",
             },
+            function: {
+              usage: "Deployment of individual function - NOT SUPPORTED",
+              shortcut: "f",
+            }
           }
         },
         options: {
@@ -64,6 +68,10 @@ export class AzureDeployPlugin extends AzureBasePlugin<AzureLoginOptions> {
           package: {
             usage: "Package to deploy",
             shortcut: "p",
+          },
+          function: {
+            usage: "Deployment of individual function - NOT SUPPORTED",
+            shortcut: "f",
           }
         }
       }
@@ -71,12 +79,14 @@ export class AzureDeployPlugin extends AzureBasePlugin<AzureLoginOptions> {
   }
 
   private async list() {
+    this.checkForIndividualFunctionDeploy();
     this.log("Listing deployments");
     const resourceService = new ResourceService(this.serverless, this.options);
     this.log(await resourceService.listDeployments());
   }
 
   private async deploy() {
+    this.checkForIndividualFunctionDeploy();
     const resourceService = new ResourceService(this.serverless, this.options);
     const functionAppService = new FunctionAppService(this.serverless, this.options);
     const zipFile = functionAppService.getFunctionZipFile();
@@ -86,5 +96,16 @@ export class AzureDeployPlugin extends AzureBasePlugin<AzureLoginOptions> {
     await resourceService.deployResourceGroup();
     const functionApp = await functionAppService.deploy();
     await functionAppService.uploadFunctions(functionApp);
+  }
+
+  /**
+   * Check to see if user tried to target an individual function for deployment or deployment list
+   * Throws error if `function` is specified
+   */
+  private checkForIndividualFunctionDeploy() {
+    if (this.options.function) {
+      throw new Error("The Azure Functions plugin does not currently support deployments of individual functions. " +
+        "Azure Functions are zipped up as a package and deployed together as a unit");
+    }
   }
 }


### PR DESCRIPTION
Azure Functions does not support deployments of individual functions. This throws an error if a user tries to target an individual function for deployment or deployment list.

Resolves #258 