### PR TITLE
fix: Throw error if user tries to specify package.individually

### DIFF
--- a/src/models/serverless.ts
+++ b/src/models/serverless.ts
@@ -50,7 +50,7 @@ export interface ServerlessAzureProvider {
   hostingEnvironment?: ResourceConfig;
   virtualNetwork?: ResourceConfig;
   armTemplate?: ArmTemplateConfig;
-  runtime: string; 
+  runtime: string;
 }
 
 export interface ServerlessAzureConfig {
@@ -58,6 +58,7 @@ export interface ServerlessAzureConfig {
   provider: ServerlessAzureProvider;
   plugins: string[];
   functions: any;
+  package: any;
 }
 
 export interface ServerlessAzureFunctionConfig {

--- a/src/plugins/azureBasePlugin.ts
+++ b/src/plugins/azureBasePlugin.ts
@@ -1,11 +1,12 @@
 import { Guard } from "../shared/guard";
 import Serverless from "serverless";
 import { Utils } from "../shared/utils";
-import { ServerlessCommandMap, ServerlessHookMap } from "../models/serverless";
+import { ServerlessCommandMap, ServerlessHookMap, ServerlessAzureConfig } from "../models/serverless";
 
 export abstract class AzureBasePlugin<TOptions=Serverless.Options> {
 
   public hooks: ServerlessHookMap
+  protected config: ServerlessAzureConfig;
   protected commands: ServerlessCommandMap;
 
   public constructor(
@@ -13,6 +14,7 @@ export abstract class AzureBasePlugin<TOptions=Serverless.Options> {
     protected options: TOptions,
   ) {
     Guard.null(serverless);
+    this.config = serverless.service as any;
   }
 
   protected log(message: string) {

--- a/src/plugins/package/azurePackagePlugin.test.ts
+++ b/src/plugins/package/azurePackagePlugin.test.ts
@@ -41,6 +41,17 @@ describe("Azure Package Plugin", () => {
     expect(PackageService.prototype.cleanUp).toBeCalled();
   });
 
+  it("Throws an error of package.individually is specified", async () => {
+    const slsService = MockFactory.createTestService();
+    slsService["package"] = { individually: true };
+    sls = MockFactory.createTestServerless({ service: slsService });
+    plugin = new AzurePackagePlugin(sls, MockFactory.createTestServerlessOptions());
+    await expect(invokeHook(plugin, "before:package:setupProviderConfiguration")).rejects.toThrow(
+      "Cannot package Azure Functions individually. " +
+      "Remove `individually` attribute from the `package` section of the serverless config"
+    );
+  });
+
   describe("Package specified in options", () => {
 
     beforeEach(() => {

--- a/src/plugins/package/azurePackagePlugin.ts
+++ b/src/plugins/package/azurePackagePlugin.ts
@@ -25,6 +25,10 @@ export class AzurePackagePlugin extends AzureBasePlugin {
       this.log("No need to create bindings. Using pre-existing package");
       return Promise.resolve();
     }
+    if (this.config.package && this.config.package.individually) {
+      throw new Error("Cannot package Azure Functions individually. " +
+        "Remove `individually` attribute from the `package` section of the serverless config");
+    }
     await this.packageService.createBindings();
     this.bindingsCreated = true;
 


### PR DESCRIPTION
Because Azure Functions does not support individually packaged functions, the plugin needs to throw an error when user tries to perform the operation.

Resolves #254 