### PR TITLE
fix: Move InvokeService variable initialization outside of the constructor header

### DIFF
--- a/src/services/invokeService.ts
+++ b/src/services/invokeService.ts
@@ -6,9 +6,11 @@ import configConstants from "../config";
 
 export class InvokeService extends BaseService {
   public functionAppService: FunctionAppService;
+  private local: boolean;
 
-  public constructor(serverless: Serverless, options: Serverless.Options, private local: boolean = false) {
+  public constructor(serverless: Serverless, options: Serverless.Options, local: boolean = false) {
     super(serverless, options, !local);
+    this.local = local;
     if (!local) {
       this.functionAppService = new FunctionAppService(serverless, options);
     }


### PR DESCRIPTION
Fixes issue where `this` was being accessed before `super` was called