### PR TITLE
fix: set up npm auth

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,2 +1,0 @@
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}
-always-auth=false # true will force npm to always require authentication when accessing the registry, even for GET requests.

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -3,6 +3,10 @@ set -eo pipefail
 
 $(pwd)/scripts/build.sh
 
+# set up .npmrc to authenticate with the provided token
+echo "Set up .npmrc ..."
+echo "//registry.npmjs.org/:_authToken=\${NPM_TOKEN}" > .npmrc
+
 # NOTE: auth is taken care of via NPM_TOKEN env variable
 if [ -z "$1" ]; then
   echo "Publishing 'latest' to NPM...";


### PR DESCRIPTION
need to set up `.npmrc` so npm can correctly authorize with the provided token