### PR TITLE
fix: Use stage, region, resourceGroup and prefix from CLI options

### DIFF
--- a/src/models/serverless.ts
+++ b/src/models/serverless.ts
@@ -99,6 +99,7 @@ export interface ServerlessCommandMap {
 }
 
 export interface ServerlessAzureOptions extends Serverless.Options {
+  prefix?: string;
   resourceGroup?: string;
 }
 

--- a/src/services/namingService.ts
+++ b/src/services/namingService.ts
@@ -123,13 +123,15 @@ export class AzureNamingService {
    * @param stageName The stage name
    */
   public static createShortStageName(stageName: string) {
-    Guard.empty(stageName);
+    Guard.empty(stageName, "stageName");
 
     const stageMap = {
       "dogfood": "df",
       "production": "prod",
+      "prod": "prod",
       "development": "dev",
-      "testing": "test"
+      "testing": "test",
+      "test": "test"
     };
 
     return this.createShortName(stageName, stageMap);
@@ -140,7 +142,7 @@ export class AzureNamingService {
    * @param regionName The region name
    */
   public static getNormalizedRegionName(regionName: string) {
-    Guard.empty(regionName);
+    Guard.empty(regionName, "regionName");
     return regionName.replace(/\W/g, "").toLowerCase();
   }
 
@@ -149,7 +151,7 @@ export class AzureNamingService {
    * @param regionName The azure region name
    */
   public static createShortAzureRegionName(regionName: string) {
-    Guard.empty(regionName);
+    Guard.empty(regionName, "regionName");
 
     const locationMap = {
       "north": "n",


### PR DESCRIPTION
Fixes a regression in accepting `region` and `stage` options from CLI to form resource group name. Adds acceptance of `prefix` as well. Does so by configuring each of them in `serverless.service` (`ServerlessAzureConfig`) as one of the first steps of the `BaseService` constructor.

Also puts `location` into `region` inside the config if `location` is specified, but `region` is not.

Resolves #280, #282 and #281 