### PR TITLE
fix: Combine rollback log statement into one string

### DIFF
--- a/src/services/rollbackService.test.ts
+++ b/src/services/rollbackService.test.ts
@@ -76,11 +76,8 @@ describe("Rollback Service", () => {
     const options = {} as any;
     const service = createService(sls, options);
     await service.rollback();
-    expect(sls.cli.log).lastCalledWith(
-      deploymentString,
-      undefined,
-      undefined
-    );
+    const logCalls: any[][] = (sls.cli.log as any).mock.calls;
+    expect(logCalls[logCalls.length - 1][0].endsWith(deploymentString)).toBe(true);
   });
 
   it("should return early with invalid timestamp", async () => {

--- a/src/services/rollbackService.ts
+++ b/src/services/rollbackService.ts
@@ -107,10 +107,10 @@ export class RollbackService extends BaseService {
   private async getDeployment(): Promise<DeploymentExtended> {
     let timestamp = Utils.get(this.options, "timestamp");
     if (!timestamp) {
-      this.log("Need to specify a timestamp for rollback.");
-      this.log("Example usage:\n\nsls rollback -t 1562014362");
-      this.log(await this.resourceService.listDeployments());
-      return null;
+      this.log("Need to specify a timestamp for rollback.\n\n" +
+        "Example usage:\n\nsls rollback -t 1562014362\n\n" +
+        await this.resourceService.listDeployments());
+      return;
     }
     const deployments = await this.getArmDeploymentsByTimestamp();
     const deployment = deployments.get(timestamp);


### PR DESCRIPTION
Strings were being logged out of order at random for some reason. Seemed cleaner anyway to just combine them into one string and adjusted tests.