### PR TITLE
fix appServicePlan name and functionApp name

### DIFF
--- a/src/armTemplates/resources/appServicePlan.ts
+++ b/src/armTemplates/resources/appServicePlan.ts
@@ -4,7 +4,7 @@ import { AzureNamingService } from "../../services/namingService";
 
 export class AppServicePlanResource implements ArmResourceTemplateGenerator {
   public static getResourceName(config: ServerlessAzureConfig) {
-    return AzureNamingService.getResourceName(config, config.provider.appInsights, "asp");
+    return AzureNamingService.getResourceName(config, config.provider.appServicePlan, "asp");
   }
 
   public getTemplate(): ArmResourceTemplate {

--- a/src/armTemplates/resources/functionApp.ts
+++ b/src/armTemplates/resources/functionApp.ts
@@ -10,7 +10,7 @@ export class FunctionAppResource implements ArmResourceTemplateGenerator {
   public static getResourceName(config: ServerlessAzureConfig) {
     const safeServiceName = config.service.replace(/\s/g, "-");
 
-    return AzureNamingService.getResourceName(config, config.provider.appInsights, safeServiceName);
+    return AzureNamingService.getResourceName(config, config.provider.functionApp, safeServiceName);
   }
 
   public getTemplate(): ArmResourceTemplate {
@@ -123,26 +123,26 @@ export class FunctionAppResource implements ArmResourceTemplateGenerator {
     };
   }
 
-  private getRuntimeVersion(runtime: string): string{ 
-    if(!runtime) {
+  private getRuntimeVersion(runtime: string): string {
+    if (!runtime) {
       throw new Error("Runtime version not specified in serverless.yml");
     }
     const extractedVersion = runtime.split("nodejs")[1];
     const runtimeVersionsList = runtimeVersionsJson["nodejs"];
 
     //Searches for a specific version. For example nodejs10.6.0.
-    if(!extractedVersion.endsWith(".x")) {
+    if (!extractedVersion.endsWith(".x")) {
       let retrivedVersion: string;
-      for(const version of runtimeVersionsList){
-        retrivedVersion = version["version"]; 
-        if(extractedVersion === retrivedVersion && semver.valid(retrivedVersion)){
-          return retrivedVersion; 
+      for (const version of runtimeVersionsList) {
+        retrivedVersion = version["version"];
+        if (extractedVersion === retrivedVersion && semver.valid(retrivedVersion)) {
+          return retrivedVersion;
         }
       }
     }
     else {
       // User specified something like nodejs10.14.x
-      const extractedVersionNumber = extractedVersion.replace(/[^0-9\.]/g,"");
+      const extractedVersionNumber = extractedVersion.replace(/[^0-9\.]/g, "");
 
       const selectedVersions = runtimeVersionsList.filter(({ version }) => {
         return version.startsWith(extractedVersionNumber) && semver.valid(version)
@@ -154,5 +154,5 @@ export class FunctionAppResource implements ArmResourceTemplateGenerator {
       return selectedVersions.sort(semver.rcompare)[0]
     }
     throw new Error(`Could not find runtime version matching ${runtime}`)
-  }  
+  }
 }


### PR DESCRIPTION
When the "name" of appServicePlan and functionApp is filled in the template, the resource created or updated have the wrong name.

see #292 