### PR TITLE
fix: Move service initialization outside of plugins

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -8,6 +8,13 @@ import { AzureLoginPlugin } from "./plugins/login/azureLoginPlugin";
 import { AzureApimServicePlugin } from "./plugins/apim/azureApimServicePlugin";
 import { AzureApimFunctionPlugin } from "./plugins/apim/azureApimFunctionPlugin";
 import AzureProvider from "./provider/azureProvider";
+import { AzureFuncPlugin } from "./plugins/func/azureFuncPlugin";
+import { AzureOfflinePlugin } from "./plugins/offline/azureOfflinePlugin";
+import { AzureRollbackPlugin } from "./plugins/rollback/azureRollbackPlugin";
+
+jest.genMockFromModule("./services/baseService");
+jest.mock("./services/baseService")
+import { BaseService } from "./services/baseService";
 
 describe("Azure Index", () => {
   it("contains all registered plugins", () => {
@@ -25,5 +32,23 @@ describe("Azure Index", () => {
     expect(sls.pluginManager.addPlugin).toBeCalledWith(AzureDeployPlugin);
     expect(sls.pluginManager.addPlugin).toBeCalledWith(AzureApimServicePlugin);
     expect(sls.pluginManager.addPlugin).toBeCalledWith(AzureApimFunctionPlugin);
+    expect(sls.pluginManager.addPlugin).toBeCalledWith(AzureFuncPlugin);
+    expect(sls.pluginManager.addPlugin).toBeCalledWith(AzureOfflinePlugin);
+    expect(sls.pluginManager.addPlugin).toBeCalledWith(AzureRollbackPlugin);
+  });
+
+  it("does not initialize BaseService in constructor of any plugin", () => {
+    const sls = MockFactory.createTestServerless();
+    const options = MockFactory.createTestServerlessOptions();
+    new AzureIndex(sls, options);
+    sls.setProvider = jest.fn();
+
+    const calls = (sls.pluginManager.addPlugin as any).mock.calls;
+
+    for (const call of calls) {
+      const pluginClass = call[0];
+      new pluginClass(MockFactory.createTestServerless(), MockFactory.createTestServerlessOptions());
+    }
+    expect(BaseService).not.toBeCalled();
   });
 });

--- a/src/plugins/func/azureFuncPlugin.ts
+++ b/src/plugins/func/azureFuncPlugin.ts
@@ -3,7 +3,6 @@ import { FuncService } from "../../services/funcService";
 import { AzureBasePlugin } from "../azureBasePlugin";
 
 export class AzureFuncPlugin extends AzureBasePlugin {
-  private service: FuncService;
 
   public constructor(serverless: Serverless, options: Serverless.Options) {
     super(serverless, options);
@@ -48,8 +47,6 @@ export class AzureFuncPlugin extends AzureBasePlugin {
         }
       }
     }
-
-    this.service = new FuncService(serverless, options);
   }
 
   private async func() {
@@ -57,10 +54,12 @@ export class AzureFuncPlugin extends AzureBasePlugin {
   }
 
   private async add() {
-    this.service.add();
+    const service = new FuncService(this.serverless, this.options);
+    service.add();
   }
 
   private async remove() {
-    this.service.remove();
+    const service = new FuncService(this.serverless, this.options);
+    service.remove();
   }
 }

--- a/src/plugins/invoke/azureInvokePlugin.ts
+++ b/src/plugins/invoke/azureInvokePlugin.ts
@@ -6,8 +6,6 @@ import { AzureBasePlugin } from "../azureBasePlugin";
 
 export class AzureInvokePlugin extends AzureBasePlugin {
 
-  private invokeService: InvokeService;
-
   public constructor(serverless: Serverless, options: Serverless.Options) {
     super(serverless, options);
     const path = this.options["path"];
@@ -117,8 +115,8 @@ export class AzureInvokePlugin extends AzureBasePlugin {
       return;
     }
 
-    this.invokeService = new InvokeService(this.serverless, this.options, local);
-    const response = await this.invokeService.invoke(method, functionName, data);
+    const invokeService = new InvokeService(this.serverless, this.options, local);
+    const response = await invokeService.invoke(method, functionName, data);
     if (response) {
       this.log(JSON.stringify(response.data));
     }

--- a/src/plugins/offline/azureOfflinePlugin.ts
+++ b/src/plugins/offline/azureOfflinePlugin.ts
@@ -3,11 +3,9 @@ import { OfflineService } from "../../services/offlineService";
 import { AzureBasePlugin } from "../azureBasePlugin";
 
 export class AzureOfflinePlugin extends AzureBasePlugin {
-  private offlineService: OfflineService;
 
   public constructor(serverless: Serverless, options: Serverless.Options) {
     super(serverless, options);
-    this.offlineService = new OfflineService(this.serverless, this.options);
 
     this.hooks = {
       "before:offline:offline": this.azureOfflineBuild.bind(this),
@@ -60,14 +58,17 @@ export class AzureOfflinePlugin extends AzureBasePlugin {
   }
 
   private async azureOfflineBuild(){
-    await this.offlineService.build();
+    const offlineService = new OfflineService(this.serverless, this.options);
+    await offlineService.build();
   }
 
   private async azureOfflineStart(){
-    await this.offlineService.start();
+    const offlineService = new OfflineService(this.serverless, this.options);
+    await offlineService.start();
   }
 
   private async azureOfflineCleanup(){
-    await this.offlineService.cleanup();
+    const offlineService = new OfflineService(this.serverless, this.options);
+    await offlineService.cleanup();
   }
 }

--- a/src/plugins/package/azurePackagePlugin.ts
+++ b/src/plugins/package/azurePackagePlugin.ts
@@ -7,7 +7,6 @@ import { ServerlessCliCommand } from "../../models/serverless";
 
 export class AzurePackagePlugin extends AzureBasePlugin {
   private bindingsCreated: boolean = false;
-  private packageService: PackageService;
   public provider: AzureProvider;
 
   public constructor(serverless: Serverless, options: Serverless.Options) {
@@ -17,11 +16,11 @@ export class AzurePackagePlugin extends AzureBasePlugin {
       "before:webpack:package:packageModules": this.webpack.bind(this),
       "after:package:finalize": this.finalize.bind(this),
     };
-
-    this.packageService = new PackageService(this.serverless, this.options);
   }
 
   private async setupProviderConfiguration(): Promise<void> {
+    const packageService = new PackageService(this.serverless, this.options);
+
     if (this.processedCommands[0] === ServerlessCliCommand.DEPLOY && this.getOption("package")) {
       this.log("Deploying pre-built package. No need to create bindings");
       return;
@@ -30,14 +29,16 @@ export class AzurePackagePlugin extends AzureBasePlugin {
       throw new Error("Cannot package Azure Functions individually. " +
         "Remove `individually` attribute from the `package` section of the serverless config");
     }
-    this.packageService.cleanUpServerlessDir();
-    await this.packageService.createBindings();
+    packageService.cleanUpServerlessDir();
+    await packageService.createBindings();
     this.bindingsCreated = true;
 
     return Promise.resolve();
   }
 
   private async webpack(): Promise<void> {
+    const packageService = new PackageService(this.serverless, this.options);
+
     if (this.getOption("package")) {
       this.log("No need to perform webpack. Using pre-existing package");
       return Promise.resolve();
@@ -46,17 +47,19 @@ export class AzurePackagePlugin extends AzureBasePlugin {
       await this.setupProviderConfiguration();
     }
 
-    await this.packageService.prepareWebpack();
+    await packageService.prepareWebpack();
   }
 
   /**
    * Cleans up generated folders & files after packaging is complete
    */
   private async finalize(): Promise<void> {
+    const packageService = new PackageService(this.serverless, this.options);
+
     if (this.getOption("package")) {
       this.log("No need to clean up generated folders & files. Using pre-existing package");
       return Promise.resolve();
     }
-    await this.packageService.cleanUp();
+    await packageService.cleanUp();
   }
 }

--- a/src/services/baseService.ts
+++ b/src/services/baseService.ts
@@ -36,7 +36,7 @@ export abstract class BaseService {
     Guard.null(serverless);
     this.setDefaultValues();
     this.config = serverless.service as any;
-    this.setConfigFromCli();
+    this.setupConfig();
 
     this.baseUrl = "https://management.azure.com";
     this.serviceName = this.getServiceName();
@@ -256,8 +256,9 @@ export abstract class BaseService {
    * Overwrite values for resourceGroup, prefix, region and stage
    * in config if passed through CLI
    */
-  private setConfigFromCli() {
+  private setupConfig() {
     const { prefix, region, stage, subscriptionId } = this.config.provider;
+
     this.config.provider = {
       ...this.config.provider,
       prefix: this.getOption("prefix") || prefix,


### PR DESCRIPTION
Fixes error we found in testing serverless optional variables (`${opt:stage, 'dev'}`), which allow you to specify a param at deploy time, as well as a default value. Also fixes potentially more serious problems with setting names before the configuration is initialized.