### PR TITLE
fix: Add backwards compatibility for location/region keys in config

### DIFF
--- a/src/services/baseService.test.ts
+++ b/src/services/baseService.test.ts
@@ -275,4 +275,18 @@ describe("Base Service", () => {
     expect(service.getSubscriptionId()).toEqual(loginResultSubscriptionId);
     expect(serverless.service.provider["subscriptionId"]).toEqual(loginResultSubscriptionId);
   });
+
+  it("sets region to be value from location property if region not set", () => {
+    const slsService = MockFactory.createTestService();
+    delete slsService.provider.region;
+    const location = "East US";
+    slsService.provider["location"] = location;
+
+    const sls = MockFactory.createTestServerless({
+      service: slsService
+    });
+
+    service = new MockService(sls, {} as any);
+    expect(service.getRegion()).toEqual(location);
+  });
 });

--- a/src/services/baseService.ts
+++ b/src/services/baseService.ts
@@ -227,7 +227,7 @@ export abstract class BaseService {
 
     if (!providerRegion || providerRegion === awsDefault) {
       // no region specified in serverless.yml
-      this.serverless.service.provider.region = "westus";
+      this.serverless.service.provider.region = this.serverless.service.provider["location"] || "westus";
     }
 
     if (!this.serverless.service.provider.stage) {
@@ -267,9 +267,6 @@ export abstract class BaseService {
         || process.env.azureSubId
         || subscriptionId
         || this.serverless.variables["subscriptionId"]
-    }
-    if (!this.config.provider.region && this.config.provider["location"]) {
-      this.config.provider.region = this.config.provider["location"];
     }
     this.config.provider.resourceGroup = (
       this.getOption("resourceGroup", this.config.provider.resourceGroup)


### PR DESCRIPTION
The key for Azure Region moved from `location` to `region`. This just adds backwards compatibility so that the value from `location` is stored in the `region` config if no other is specified.

Resolves #280 