### PR TITLE
feat: More detailed error message upon ARM deployment failure

### DIFF
--- a/src/models/azureProvider.ts
+++ b/src/models/azureProvider.ts
@@ -18,3 +18,9 @@ export interface FunctionMetadata {
   handler: string;
   events: FunctionEvent[];
 }
+
+export interface DeploymentExtendedError {
+  code: string;
+  message: string;
+  details?: DeploymentExtendedError[];
+}


### PR DESCRIPTION
Logs a more detailed error message when an ARM template deployment fails:

![image](https://user-images.githubusercontent.com/10962815/64280926-f0e7fe80-cf06-11e9-856b-895380038168.png)
