### PR TITLE
fix: add resource group name hash to resource names

### DIFF
--- a/src/armTemplates/resources/apim.test.ts
+++ b/src/armTemplates/resources/apim.test.ts
@@ -1,0 +1,54 @@
+import { ApimResource } from "./apim"
+import { ServerlessAzureConfig } from "../../models/serverless";
+import md5 from "md5";
+import configConstants from "../../config";
+import { MockFactory } from "../../test/mockFactory"
+
+describe("APIM Resource", () => {
+
+  const resourceGroupName = "myResourceGroup";
+    const serviceName = "myServiceName";
+    const prefix = "prefix";
+    const region = "eastus2";
+    const stage = "prod";
+
+  it("generates the correct resource name", () => {
+    const resourceGroupHash = md5(resourceGroupName).substr(0, configConstants.resourceGroupHashLength);
+
+    const config: ServerlessAzureConfig = {
+      provider: {
+        name: "azure",
+        prefix,
+        region,
+        stage,
+        resourceGroup: resourceGroupName,
+        runtime: "nodejs10.x"
+      },
+      service: ""
+    } as any;
+
+    expect(ApimResource.getResourceName(config)).toEqual(
+      `${prefix}-eus2-${stage}-${resourceGroupHash}-apim`);
+  });
+
+  it("uses the specified name from the azure provider", () => {
+    const apimName = "myAPIM";
+
+    const config: ServerlessAzureConfig = {
+      provider: {
+        apim: {
+          name: apimName
+        },
+        name: "azure",
+        prefix,
+        region,
+        stage,
+        resourceGroup: resourceGroupName,
+        runtime: "nodejs10.x"
+      },
+      service: ""
+    } as any;
+
+    expect(ApimResource.getResourceName(config)).toEqual(apimName);
+  });
+});

--- a/src/armTemplates/resources/apim.ts
+++ b/src/armTemplates/resources/apim.ts
@@ -1,11 +1,16 @@
 import { ApiManagementConfig } from "../../models/apiManagement";
 import { ArmResourceTemplate, ArmResourceTemplateGenerator } from "../../models/armTemplates";
 import { ServerlessAzureConfig } from "../../models/serverless";
-import { AzureNamingService } from "../../services/namingService";
+import { AzureNamingService, AzureNamingServiceOptions } from "../../services/namingService";
 
 export class ApimResource implements ArmResourceTemplateGenerator {
   public static getResourceName(config: ServerlessAzureConfig) {
-    return AzureNamingService.getResourceName(config, config.provider.apim, "apim");
+    const options: AzureNamingServiceOptions = {
+      config,
+      resourceConfig: config.provider.apim,
+      suffix: "apim",
+    }
+    return AzureNamingService.getResourceName(options);
   }
 
   public getTemplate(): ArmResourceTemplate {

--- a/src/armTemplates/resources/appInsights.test.ts
+++ b/src/armTemplates/resources/appInsights.test.ts
@@ -1,9 +1,9 @@
-import { ApimResource } from "./apim";
+import { AppInsightsResource } from "./appInsights";
 import { ServerlessAzureConfig } from "../../models/serverless";
 import md5 from "md5";
 import configConstants from "../../config";
 
-describe("APIM Resource", () => {
+describe("App Insights Resource", () => {
   const resourceGroupName = "myResourceGroup";
   const prefix = "prefix";
   const region = "eastus2";
@@ -27,29 +27,8 @@ describe("APIM Resource", () => {
       service: ""
     } as any;
 
-    expect(ApimResource.getResourceName(config)).toEqual(
-      `${prefix}-eus2-${stage}-${resourceGroupHash}-apim`
+    expect(AppInsightsResource.getResourceName(config)).toEqual(
+      `${prefix}-eus2-${stage}-${resourceGroupHash}-appinsights`
     );
-  });
-
-  it("uses the specified name from the azure provider", () => {
-    const apimName = "myAPIM";
-
-    const config: ServerlessAzureConfig = {
-      provider: {
-        apim: {
-          name: apimName
-        },
-        name: "azure",
-        prefix,
-        region,
-        stage,
-        resourceGroup: resourceGroupName,
-        runtime: "nodejs10.x"
-      },
-      service: ""
-    } as any;
-
-    expect(ApimResource.getResourceName(config)).toEqual(apimName);
   });
 });

--- a/src/armTemplates/resources/appInsights.test.ts
+++ b/src/armTemplates/resources/appInsights.test.ts
@@ -31,4 +31,25 @@ describe("App Insights Resource", () => {
       `${prefix}-eus2-${stage}-${resourceGroupHash}-appinsights`
     );
   });
+
+  it("uses the specified name from the azure provider", () => {
+    const appInsightsName = "myAppInsights";
+
+    const config: ServerlessAzureConfig = {
+      provider: {
+        name: "azure",
+        prefix,
+        region,
+        stage,
+        resourceGroup: resourceGroupName,
+        runtime: "nodejs10.x",
+        appInsights: {
+          name: appInsightsName,
+        },
+      },
+      service: "myapp",
+    } as any;
+
+    expect(AppInsightsResource.getResourceName(config)).toEqual(appInsightsName);
+  });
 });

--- a/src/armTemplates/resources/appInsights.ts
+++ b/src/armTemplates/resources/appInsights.ts
@@ -1,10 +1,15 @@
 import { ArmResourceTemplate, ArmResourceTemplateGenerator } from "../../models/armTemplates";
 import { ServerlessAzureConfig } from "../../models/serverless";
-import { AzureNamingService } from "../../services/namingService";
+import { AzureNamingService, AzureNamingServiceOptions } from "../../services/namingService";
 
 export class AppInsightsResource implements ArmResourceTemplateGenerator {
   public static getResourceName(config: ServerlessAzureConfig) {
-    return AzureNamingService.getResourceName(config, config.provider.appInsights, "appinsights");
+    const options: AzureNamingServiceOptions = {
+      config,
+      resourceConfig: config.provider.appInsights,
+      suffix: "appinsights",
+    }
+    return AzureNamingService.getResourceName(options);
   }
 
   public getTemplate(): ArmResourceTemplate {

--- a/src/armTemplates/resources/appServicePlan.test.ts
+++ b/src/armTemplates/resources/appServicePlan.test.ts
@@ -31,4 +31,25 @@ describe("App Service Plan Resource", () => {
       `${prefix}-eus2-${stage}-${resourceGroupHash}-asp`
     );
   });
+
+  it("uses the specified name from the azure provider", () => {
+    const appServicePlanName = "myAppServicePlan";
+
+    const config: ServerlessAzureConfig = {
+      provider: {
+        name: "azure",
+        prefix,
+        region,
+        stage,
+        resourceGroup: resourceGroupName,
+        runtime: "nodejs10.x",
+        appServicePlan: {
+          name: appServicePlanName,
+        },
+      },
+      service: "myapp",
+    } as any;
+
+    expect(AppServicePlanResource.getResourceName(config)).toEqual(appServicePlanName);
+  });
 });

--- a/src/armTemplates/resources/appServicePlan.test.ts
+++ b/src/armTemplates/resources/appServicePlan.test.ts
@@ -1,9 +1,9 @@
-import { ApimResource } from "./apim";
+import { AppServicePlanResource } from "./appServicePlan";
 import { ServerlessAzureConfig } from "../../models/serverless";
 import md5 from "md5";
 import configConstants from "../../config";
 
-describe("APIM Resource", () => {
+describe("App Service Plan Resource", () => {
   const resourceGroupName = "myResourceGroup";
   const prefix = "prefix";
   const region = "eastus2";
@@ -27,29 +27,8 @@ describe("APIM Resource", () => {
       service: ""
     } as any;
 
-    expect(ApimResource.getResourceName(config)).toEqual(
-      `${prefix}-eus2-${stage}-${resourceGroupHash}-apim`
+    expect(AppServicePlanResource.getResourceName(config)).toEqual(
+      `${prefix}-eus2-${stage}-${resourceGroupHash}-asp`
     );
-  });
-
-  it("uses the specified name from the azure provider", () => {
-    const apimName = "myAPIM";
-
-    const config: ServerlessAzureConfig = {
-      provider: {
-        apim: {
-          name: apimName
-        },
-        name: "azure",
-        prefix,
-        region,
-        stage,
-        resourceGroup: resourceGroupName,
-        runtime: "nodejs10.x"
-      },
-      service: ""
-    } as any;
-
-    expect(ApimResource.getResourceName(config)).toEqual(apimName);
   });
 });

--- a/src/armTemplates/resources/appServicePlan.ts
+++ b/src/armTemplates/resources/appServicePlan.ts
@@ -1,10 +1,15 @@
 import { ArmResourceTemplate, ArmResourceTemplateGenerator } from "../../models/armTemplates";
 import { ResourceConfig, ServerlessAzureConfig } from "../../models/serverless";
-import { AzureNamingService } from "../../services/namingService";
+import { AzureNamingService, AzureNamingServiceOptions } from "../../services/namingService";
 
 export class AppServicePlanResource implements ArmResourceTemplateGenerator {
   public static getResourceName(config: ServerlessAzureConfig) {
-    return AzureNamingService.getResourceName(config, config.provider.appServicePlan, "asp");
+    const options: AzureNamingServiceOptions = {
+      config,
+      resourceConfig: config.provider.appServicePlan,
+      suffix: "asp",
+    }
+    return AzureNamingService.getResourceName(options);
   }
 
   public getTemplate(): ArmResourceTemplate {

--- a/src/armTemplates/resources/functionApp.test.ts
+++ b/src/armTemplates/resources/functionApp.test.ts
@@ -1,20 +1,13 @@
-import { ApimResource } from "./apim";
+import { FunctionAppResource } from "./functionApp";
 import { ServerlessAzureConfig } from "../../models/serverless";
-import md5 from "md5";
-import configConstants from "../../config";
 
-describe("APIM Resource", () => {
+describe("Function App Resource", () => {
   const resourceGroupName = "myResourceGroup";
   const prefix = "prefix";
-  const region = "eastus2";
+  const region = "westus";
   const stage = "prod";
 
   it("generates the correct resource name", () => {
-    const resourceGroupHash = md5(resourceGroupName).substr(
-      0,
-      configConstants.resourceGroupHashLength
-    );
-
     const config: ServerlessAzureConfig = {
       provider: {
         name: "azure",
@@ -27,18 +20,18 @@ describe("APIM Resource", () => {
       service: ""
     } as any;
 
-    expect(ApimResource.getResourceName(config)).toEqual(
-      `${prefix}-eus2-${stage}-${resourceGroupHash}-apim`
+    expect(FunctionAppResource.getResourceName(config)).toEqual(
+      `${config.provider.prefix}-wus-${config.provider.stage}`
     );
   });
 
   it("uses the specified name from the azure provider", () => {
-    const apimName = "myAPIM";
+    const serviceName = "myapp";
 
     const config: ServerlessAzureConfig = {
       provider: {
         apim: {
-          name: apimName
+          name: ""
         },
         name: "azure",
         prefix,
@@ -47,9 +40,11 @@ describe("APIM Resource", () => {
         resourceGroup: resourceGroupName,
         runtime: "nodejs10.x"
       },
-      service: ""
+      service: serviceName
     } as any;
 
-    expect(ApimResource.getResourceName(config)).toEqual(apimName);
+    expect(FunctionAppResource.getResourceName(config)).toEqual(
+      `${config.provider.prefix}-wus-${config.provider.stage}-${serviceName}`
+    );
   });
 });

--- a/src/armTemplates/resources/functionApp.test.ts
+++ b/src/armTemplates/resources/functionApp.test.ts
@@ -38,13 +38,14 @@ describe("Function App Resource", () => {
         region,
         stage,
         resourceGroup: resourceGroupName,
-        runtime: "nodejs10.x"
+        runtime: "nodejs10.x",
+        functionApp: {
+          name: serviceName,
+        },
       },
       service: serviceName
     } as any;
 
-    expect(FunctionAppResource.getResourceName(config)).toEqual(
-      `${config.provider.prefix}-wus-${config.provider.stage}-${serviceName}`
-    );
+    expect(FunctionAppResource.getResourceName(config)).toEqual(serviceName);
   });
 });

--- a/src/armTemplates/resources/functionApp.ts
+++ b/src/armTemplates/resources/functionApp.ts
@@ -1,6 +1,6 @@
 import { ArmResourceTemplate, ArmResourceTemplateGenerator } from "../../models/armTemplates";
 import { FunctionAppConfig, ServerlessAzureConfig } from "../../models/serverless";
-import { AzureNamingService } from "../../services/namingService";
+import { AzureNamingService, AzureNamingServiceOptions } from "../../services/namingService";
 
 //Runtime versions found at " https://<sitename>.scm.azurewebsites.net/api/diagnostics/runtime".
 import runtimeVersionsJson from "../../services/runtimeVersions.json";
@@ -9,8 +9,14 @@ import semver from "semver";
 export class FunctionAppResource implements ArmResourceTemplateGenerator {
   public static getResourceName(config: ServerlessAzureConfig) {
     const safeServiceName = config.service.replace(/\s/g, "-");
+    const options: AzureNamingServiceOptions = {
+      config,
+      resourceConfig: config.provider.functionApp,
+      suffix: safeServiceName,
+      includeHash: false,
+    }
 
-    return AzureNamingService.getResourceName(config, config.provider.functionApp, safeServiceName, false);
+    return AzureNamingService.getResourceName(options);
   }
 
   public getTemplate(): ArmResourceTemplate {

--- a/src/armTemplates/resources/functionApp.ts
+++ b/src/armTemplates/resources/functionApp.ts
@@ -10,7 +10,7 @@ export class FunctionAppResource implements ArmResourceTemplateGenerator {
   public static getResourceName(config: ServerlessAzureConfig) {
     const safeServiceName = config.service.replace(/\s/g, "-");
 
-    return AzureNamingService.getResourceName(config, config.provider.functionApp, safeServiceName);
+    return AzureNamingService.getResourceName(config, config.provider.functionApp, safeServiceName, false);
   }
 
   public getTemplate(): ArmResourceTemplate {

--- a/src/armTemplates/resources/hostingEnvironment.test.ts
+++ b/src/armTemplates/resources/hostingEnvironment.test.ts
@@ -31,4 +31,25 @@ describe("Azure Hosting Environment Resource", () => {
       `${prefix}-eus2-${stage}-${resourceGroupHash}-ase`
     );
   });
+
+  it("uses the specified name from the azure provider", () => {
+    const hostingEnvironmentName = "myHostingEnv";
+
+    const config: ServerlessAzureConfig = {
+      provider: {
+        hostingEnvironment: {
+          name: hostingEnvironmentName
+        },
+        name: "azure",
+        prefix,
+        region,
+        stage,
+        resourceGroup: resourceGroupName,
+        runtime: "nodejs10.x"
+      },
+      service: ""
+    } as any;
+
+    expect(HostingEnvironmentResource.getResourceName(config)).toEqual(hostingEnvironmentName);
+  });
 });

--- a/src/armTemplates/resources/hostingEnvironment.test.ts
+++ b/src/armTemplates/resources/hostingEnvironment.test.ts
@@ -1,9 +1,9 @@
-import { ApimResource } from "./apim";
+import { HostingEnvironmentResource } from "./hostingEnvironment";
 import { ServerlessAzureConfig } from "../../models/serverless";
 import md5 from "md5";
 import configConstants from "../../config";
 
-describe("APIM Resource", () => {
+describe("Azure Hosting Environment Resource", () => {
   const resourceGroupName = "myResourceGroup";
   const prefix = "prefix";
   const region = "eastus2";
@@ -27,29 +27,8 @@ describe("APIM Resource", () => {
       service: ""
     } as any;
 
-    expect(ApimResource.getResourceName(config)).toEqual(
-      `${prefix}-eus2-${stage}-${resourceGroupHash}-apim`
+    expect(HostingEnvironmentResource.getResourceName(config)).toEqual(
+      `${prefix}-eus2-${stage}-${resourceGroupHash}-ase`
     );
-  });
-
-  it("uses the specified name from the azure provider", () => {
-    const apimName = "myAPIM";
-
-    const config: ServerlessAzureConfig = {
-      provider: {
-        apim: {
-          name: apimName
-        },
-        name: "azure",
-        prefix,
-        region,
-        stage,
-        resourceGroup: resourceGroupName,
-        runtime: "nodejs10.x"
-      },
-      service: ""
-    } as any;
-
-    expect(ApimResource.getResourceName(config)).toEqual(apimName);
   });
 });

--- a/src/armTemplates/resources/hostingEnvironment.ts
+++ b/src/armTemplates/resources/hostingEnvironment.ts
@@ -1,10 +1,15 @@
 import { ArmResourceTemplate, ArmResourceTemplateGenerator } from "../../models/armTemplates";
 import { ServerlessAzureConfig } from "../../models/serverless";
-import { AzureNamingService } from "../../services/namingService";
+import { AzureNamingService, AzureNamingServiceOptions } from "../../services/namingService";
 
 export class HostingEnvironmentResource implements ArmResourceTemplateGenerator {
   public static getResourceName(config: ServerlessAzureConfig) {
-    return AzureNamingService.getResourceName(config, config.provider.hostingEnvironment, "ase");
+    const options: AzureNamingServiceOptions = {
+      config,
+      resourceConfig: config.provider.hostingEnvironment,
+      suffix: "ase",
+    }
+    return AzureNamingService.getResourceName(options);
   }
 
   public getTemplate(): ArmResourceTemplate {

--- a/src/armTemplates/resources/storageAccount.test.ts
+++ b/src/armTemplates/resources/storageAccount.test.ts
@@ -15,10 +15,11 @@ describe("Storage Account Resource", () => {
       name: "azure",
       region: "westus",
       stage: "dev",
-      resourceGroup
+      resourceGroup,
+      runtime: "nodejs10.x"
     },
     service: "test-api"
-  }
+  } as any;
 
   it("Generates safe storage account name with short parts", () => {
     const testConfig: ServerlessAzureConfig = {

--- a/src/armTemplates/resources/storageAccount.ts
+++ b/src/armTemplates/resources/storageAccount.ts
@@ -1,16 +1,18 @@
 import { ArmResourceTemplate, ArmResourceTemplateGenerator } from "../../models/armTemplates";
 import { ResourceConfig, ServerlessAzureConfig } from "../../models/serverless";
-import { AzureNamingService } from "../../services/namingService";
+import { AzureNamingService, AzureNamingServiceOptions } from "../../services/namingService";
 import configConstants from "../../config";
 
 export class StorageAccountResource implements ArmResourceTemplateGenerator {
   public static getResourceName(config: ServerlessAzureConfig) {
-    return AzureNamingService.getSafeResourceName(
+    const options: AzureNamingServiceOptions = {
       config,
-      configConstants.naming.maxLength.storageAccount,
-      config.provider.storageAccount,
-      "",
-      true
+      resourceConfig: config.provider.storageAccount,
+      suffix: "",
+    }
+    return AzureNamingService.getSafeResourceName(
+      options,
+      configConstants.naming.maxLength.storageAccount
     );
   }
 

--- a/src/armTemplates/resources/storageAccount.ts
+++ b/src/armTemplates/resources/storageAccount.ts
@@ -1,6 +1,12 @@
-import { ArmResourceTemplate, ArmResourceTemplateGenerator } from "../../models/armTemplates";
+import {
+  ArmResourceTemplate,
+  ArmResourceTemplateGenerator
+} from "../../models/armTemplates";
 import { ResourceConfig, ServerlessAzureConfig } from "../../models/serverless";
-import { AzureNamingService, AzureNamingServiceOptions } from "../../services/namingService";
+import {
+  AzureNamingService,
+  AzureNamingServiceOptions
+} from "../../services/namingService";
 import configConstants from "../../config";
 
 export class StorageAccountResource implements ArmResourceTemplateGenerator {
@@ -8,66 +14,67 @@ export class StorageAccountResource implements ArmResourceTemplateGenerator {
     const options: AzureNamingServiceOptions = {
       config,
       resourceConfig: config.provider.storageAccount,
-      suffix: "",
-    }
-    return AzureNamingService.getSafeResourceName(
-      options,
-      configConstants.naming.maxLength.storageAccount
-    );
+      suffix: ""
+    };
+    return AzureNamingService.getSafeResourceName({
+      ...options,
+      maxLength: configConstants.naming.maxLength.storageAccount
+    });
   }
 
   public getTemplate(): ArmResourceTemplate {
     return {
-      "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
-      "contentVersion": "1.0.0.0",
-      "parameters": {
-        "storageAccountName": {
-          "defaultValue": "",
-          "type": "String"
+      $schema:
+        "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
+      contentVersion: "1.0.0.0",
+      parameters: {
+        storageAccountName: {
+          defaultValue: "",
+          type: "String"
         },
-        "location": {
-          "defaultValue": "",
-          "type": "String"
+        location: {
+          defaultValue: "",
+          type: "String"
         },
-        "storageAccountSkuName": {
-          "defaultValue": "Standard_LRS",
-          "type": "String"
+        storageAccountSkuName: {
+          defaultValue: "Standard_LRS",
+          type: "String"
         },
-        "storageAccoutSkuTier": {
-          "defaultValue": "Standard",
-          "type": "String"
+        storageAccoutSkuTier: {
+          defaultValue: "Standard",
+          type: "String"
         }
       },
-      "variables": {},
-      "resources": [
+      variables: {},
+      resources: [
         {
-          "apiVersion": "2018-07-01",
-          "name": "[parameters('storageAccountName')]",
-          "type": "Microsoft.Storage/storageAccounts",
-          "location": "[parameters('location')]",
-          "kind": "Storage",
-          "properties": {
-            "accountType": "[parameters('storageAccountSkuName')]"
+          apiVersion: "2018-07-01",
+          name: "[parameters('storageAccountName')]",
+          type: "Microsoft.Storage/storageAccounts",
+          location: "[parameters('location')]",
+          kind: "Storage",
+          properties: {
+            accountType: "[parameters('storageAccountSkuName')]"
           },
-          "sku": {
-            "name": "[parameters('storageAccountSkuName')]",
-            "tier": "[parameters('storageAccoutSkuTier')]"
+          sku: {
+            name: "[parameters('storageAccountSkuName')]",
+            tier: "[parameters('storageAccoutSkuTier')]"
           }
         }
       ]
-    }
+    };
   }
 
   public getParameters(config: ServerlessAzureConfig): any {
     const resourceConfig: ResourceConfig = {
       sku: {},
-      ...config.provider.storageAccount,
+      ...config.provider.storageAccount
     };
 
     return {
       storageAccountName: StorageAccountResource.getResourceName(config),
       storageAccountSkuName: resourceConfig.sku.name,
-      storageAccoutSkuTier: resourceConfig.sku.tier,
+      storageAccoutSkuTier: resourceConfig.sku.tier
     };
   }
 }

--- a/src/armTemplates/resources/virtualNetwork.test.ts
+++ b/src/armTemplates/resources/virtualNetwork.test.ts
@@ -1,9 +1,9 @@
-import { ApimResource } from "./apim";
+import { VirtualNetworkResource } from "./virtualNetwork";
 import { ServerlessAzureConfig } from "../../models/serverless";
 import md5 from "md5";
 import configConstants from "../../config";
 
-describe("APIM Resource", () => {
+describe("Virtual Network Resource", () => {
   const resourceGroupName = "myResourceGroup";
   const prefix = "prefix";
   const region = "eastus2";
@@ -27,29 +27,8 @@ describe("APIM Resource", () => {
       service: ""
     } as any;
 
-    expect(ApimResource.getResourceName(config)).toEqual(
-      `${prefix}-eus2-${stage}-${resourceGroupHash}-apim`
+    expect(VirtualNetworkResource.getResourceName(config)).toEqual(
+      `${prefix}-eus2-${stage}-${resourceGroupHash}-vnet`
     );
-  });
-
-  it("uses the specified name from the azure provider", () => {
-    const apimName = "myAPIM";
-
-    const config: ServerlessAzureConfig = {
-      provider: {
-        apim: {
-          name: apimName
-        },
-        name: "azure",
-        prefix,
-        region,
-        stage,
-        resourceGroup: resourceGroupName,
-        runtime: "nodejs10.x"
-      },
-      service: ""
-    } as any;
-
-    expect(ApimResource.getResourceName(config)).toEqual(apimName);
   });
 });

--- a/src/armTemplates/resources/virtualNetwork.test.ts
+++ b/src/armTemplates/resources/virtualNetwork.test.ts
@@ -31,4 +31,25 @@ describe("Virtual Network Resource", () => {
       `${prefix}-eus2-${stage}-${resourceGroupHash}-vnet`
     );
   });
+
+  it("uses the specified name from the azure provider", () => {
+    const virtualNetworkName = "myVNET";
+
+    const config: ServerlessAzureConfig = {
+      provider: {
+        hostingEnvironment: {
+          name: virtualNetworkName
+        },
+        name: "azure",
+        prefix,
+        region,
+        stage,
+        resourceGroup: resourceGroupName,
+        runtime: "nodejs10.x"
+      },
+      service: ""
+    } as any;
+
+    expect(VirtualNetworkResource.getResourceName(config)).toEqual(virtualNetworkName);
+  });
 });

--- a/src/armTemplates/resources/virtualNetwork.ts
+++ b/src/armTemplates/resources/virtualNetwork.ts
@@ -1,14 +1,15 @@
 import { ArmResourceTemplate, ArmResourceTemplateGenerator } from "../../models/armTemplates";
 import { ServerlessAzureConfig } from "../../models/serverless";
-import { AzureNamingService } from "../../services/namingService";
+import { AzureNamingService, AzureNamingServiceOptions } from "../../services/namingService";
 
 export class VirtualNetworkResource implements ArmResourceTemplateGenerator {
   public static getResourceName(config: ServerlessAzureConfig) {
-    return AzureNamingService.getResourceName(
+    const options: AzureNamingServiceOptions = {
       config,
-      config.provider.hostingEnvironment,
-      "vnet"
-    );
+      resourceConfig: config.provider.hostingEnvironment,
+      suffix: "vnet",
+    }
+    return AzureNamingService.getResourceName(options);
   }
 
   public getTemplate(): ArmResourceTemplate {

--- a/src/services/baseService.ts
+++ b/src/services/baseService.ts
@@ -271,6 +271,6 @@ export abstract class BaseService {
     }
     this.config.provider.resourceGroup = (
       this.getOption("resourceGroup", this.config.provider.resourceGroup)
-    ) || AzureNamingService.getResourceName(this.config, null, `${this.getServiceName()}-rg`);
+    ) || AzureNamingService.getResourceName(this.config, null, `${this.getServiceName()}-rg`, false);
   }
 }

--- a/src/services/baseService.ts
+++ b/src/services/baseService.ts
@@ -14,7 +14,7 @@ import {
 } from "../models/serverless";
 import { Guard } from "../shared/guard";
 import { Utils } from "../shared/utils";
-import { AzureNamingService } from "./namingService";
+import { AzureNamingService, AzureNamingServiceOptions } from "./namingService";
 
 export abstract class BaseService {
   protected baseUrl: string;
@@ -259,6 +259,12 @@ export abstract class BaseService {
   private setupConfig() {
     const { prefix, region, stage, subscriptionId } = this.config.provider;
 
+    const options: AzureNamingServiceOptions = {
+      config: this.config,
+      suffix: `${this.getServiceName()}-rg`,
+      includeHash: false,
+    }
+
     this.config.provider = {
       ...this.config.provider,
       prefix: this.getOption("prefix") || prefix,
@@ -271,6 +277,6 @@ export abstract class BaseService {
     }
     this.config.provider.resourceGroup = (
       this.getOption("resourceGroup", this.config.provider.resourceGroup)
-    ) || AzureNamingService.getResourceName(this.config, null, `${this.getServiceName()}-rg`, false);
+    ) || AzureNamingService.getResourceName(options);
   }
 }

--- a/src/services/namingService.test.ts
+++ b/src/services/namingService.test.ts
@@ -6,27 +6,26 @@ describe("Naming Service", () => {
 
   const resourceGroup = "myResourceGroup";
   const resourceGroupHash = md5(resourceGroup).substr(0, 6);
+  const defaultConfig: ServerlessAzureConfig = {
+    functions: [],
+    plugins: [],
+    provider: {
+      prefix: "sls",
+      name: "azure",
+      region: "westus",
+      stage: "dev",
+      resourceGroup,
+      runtime: "nodejs10.x"
+    },
+    service: "test-api",
+    package: {
+      artifact: "",
+      artifactDirectoryName: "",
+      individually: false,
+    }
+  };
 
   it("Gets resource name with hash", () => {
-    const config: ServerlessAzureConfig = {
-      functions: [],
-      plugins: [],
-      provider: {
-        prefix: "sls",
-        name: "azure",
-        region: "westus",
-        stage: "dev",
-        resourceGroup,
-        runtime: "nodejs10.x"
-      },
-      service: "test-api",
-      package: {
-        artifact: "",
-        artifactDirectoryName: "",
-        individually: false,
-      }
-    };
-    
     const result = AzureNamingService.getResourceName(config);
 
     expect(result).toEqual(`${config.provider.prefix}-wus-${config.provider.stage}-${resourceGroupHash}`);

--- a/src/services/namingService.test.ts
+++ b/src/services/namingService.test.ts
@@ -25,10 +25,28 @@ describe("Naming Service", () => {
     }
   };
 
-  it("Gets resource name with hash", () => {
-    const result = AzureNamingService.getResourceName(config);
+  it("Gets resource name with hash by default", () => {
+    const result = AzureNamingService.getResourceName(defaultConfig);
 
-    expect(result).toEqual(`${config.provider.prefix}-wus-${config.provider.stage}-${resourceGroupHash}`);
+    expect(result).toEqual(`${defaultConfig.provider.prefix}-wus-${defaultConfig.provider.stage}-${resourceGroupHash}`);
+  });
+
+  it("Gets resource name without hash when specified", () => {
+    const result = AzureNamingService.getResourceName(defaultConfig, {} as any, undefined, false);
+
+    expect(result).toEqual(`${defaultConfig.provider.prefix}-wus-${defaultConfig.provider.stage}`);
+  });
+
+  it("Gets resource name with suffix", () => {
+    const result = AzureNamingService.getResourceName(defaultConfig, {} as any, "suf");
+
+    expect(result).toEqual(`${defaultConfig.provider.prefix}-wus-${defaultConfig.provider.stage}-${resourceGroupHash}-suf`);
+  });
+
+  it("Uses resource name from config if specified", () => {
+    const result = AzureNamingService.getResourceName(defaultConfig, {name: "test-resource"} as any);
+
+    expect(result).toEqual("test-resource");
   });
 
   it("Creates a short name for an azure region", () => {
@@ -117,42 +135,19 @@ describe("Naming Service", () => {
   });
 
   it("deployment name is generated correctly", () => {
-    const config: ServerlessAzureConfig = {
-      functions: [],
-      plugins: [],
-      provider: {
-        prefix: "sls",
-        name: "azure",
-        region: "westus",
-        stage: "dev",
-        resourceGroup,
-        runtime: "nodejs10.x"
-      },
-      service: "test-api",
-      package: {
-        artifact: "",
-        artifactDirectoryName: "",
-        individually: false,
-      }
-    };
-
     const timestamp = Date.now();
-    const deploymentName = AzureNamingService.getDeploymentName(config, `t${timestamp}`);
+    const deploymentName = AzureNamingService.getDeploymentName(defaultConfig, `t${timestamp}`);
 
     expect(deploymentName).toEqual(`slswusdevtestapi-DEPLOYMENT-t${timestamp}`);
-    assertValidDeploymentName(config, deploymentName, timestamp);
+    assertValidDeploymentName(defaultConfig, deploymentName, timestamp);
   });
 
   it("deployment name with long suffix or service name generated correctly", () => {
     const config: ServerlessAzureConfig = {
-      functions: [],
-      plugins: [],
+      ...defaultConfig,
       provider: {
-        prefix: "sls-long-prefix-name",
-        name: "azure",
-        region: "westus",
-        stage: "multicloud",
-        resourceGroup,
+        ...defaultConfig.provider,
+        prefix: "sls-long-prefix-name"
       },
       service: "extra-long-service-name"
     };
@@ -160,7 +155,7 @@ describe("Naming Service", () => {
     const timestamp = Date.now();
     const deploymentName = AzureNamingService.getDeploymentName(config, `t${timestamp}`);
 
-    expect(deploymentName).toEqual(`slswusmulext-DEPLOYMENT-t${timestamp}`);
+    expect(deploymentName).toEqual(`slswusdevext-DEPLOYMENT-t${timestamp}`);
     assertValidDeploymentName(config, deploymentName, timestamp);
   });
 

--- a/src/services/namingService.test.ts
+++ b/src/services/namingService.test.ts
@@ -1,4 +1,4 @@
-import { AzureNamingService } from "./namingService"
+import { AzureNamingService, AzureNamingServiceOptions } from "./namingService"
 import { ServerlessAzureConfig } from "../models/serverless";
 import md5 from "md5";
 
@@ -26,25 +26,28 @@ describe("Naming Service", () => {
   };
 
   it("Gets resource name with hash by default", () => {
-    const result = AzureNamingService.getResourceName(defaultConfig);
+    const result = AzureNamingService.getResourceName({config: defaultConfig});
 
     expect(result).toEqual(`${defaultConfig.provider.prefix}-wus-${defaultConfig.provider.stage}-${resourceGroupHash}`);
   });
 
   it("Gets resource name without hash when specified", () => {
-    const result = AzureNamingService.getResourceName(defaultConfig, {} as any, undefined, false);
+    const options: AzureNamingServiceOptions = {config: defaultConfig, includeHash: false};
+    const result = AzureNamingService.getResourceName(options);
 
     expect(result).toEqual(`${defaultConfig.provider.prefix}-wus-${defaultConfig.provider.stage}`);
   });
 
   it("Gets resource name with suffix", () => {
-    const result = AzureNamingService.getResourceName(defaultConfig, {} as any, "suf");
+    const options: AzureNamingServiceOptions = {config: defaultConfig, suffix: "suf"};
+    const result = AzureNamingService.getResourceName(options);
 
     expect(result).toEqual(`${defaultConfig.provider.prefix}-wus-${defaultConfig.provider.stage}-${resourceGroupHash}-suf`);
   });
 
   it("Uses resource name from config if specified", () => {
-    const result = AzureNamingService.getResourceName(defaultConfig, {name: "test-resource"} as any);
+    const options: AzureNamingServiceOptions = {config: defaultConfig, resourceConfig: {name: "test-resource"} as any};
+    const result = AzureNamingService.getResourceName(options);
 
     expect(result).toEqual("test-resource");
   });

--- a/src/services/namingService.test.ts
+++ b/src/services/namingService.test.ts
@@ -1,9 +1,36 @@
 import { AzureNamingService } from "./namingService"
 import { ServerlessAzureConfig } from "../models/serverless";
+import md5 from "md5";
 
 describe("Naming Service", () => {
 
   const resourceGroup = "myResourceGroup";
+  const resourceGroupHash = md5(resourceGroup).substr(0, 6);
+
+  it("Gets resource name with hash", () => {
+    const config: ServerlessAzureConfig = {
+      functions: [],
+      plugins: [],
+      provider: {
+        prefix: "sls",
+        name: "azure",
+        region: "westus",
+        stage: "dev",
+        resourceGroup,
+        runtime: "nodejs10.x"
+      },
+      service: "test-api",
+      package: {
+        artifact: "",
+        artifactDirectoryName: "",
+        individually: false,
+      }
+    };
+    
+    const result = AzureNamingService.getResourceName(config);
+
+    expect(result).toEqual(`${config.provider.prefix}-wus-${config.provider.stage}-${resourceGroupHash}`);
+  });
 
   it("Creates a short name for an azure region", () => {
     const expected = "ausse";
@@ -100,8 +127,14 @@ describe("Naming Service", () => {
         region: "westus",
         stage: "dev",
         resourceGroup,
+        runtime: "nodejs10.x"
       },
-      service: "test-api"
+      service: "test-api",
+      package: {
+        artifact: "",
+        artifactDirectoryName: "",
+        individually: false,
+      }
     };
 
     const timestamp = Date.now();

--- a/src/services/namingService.ts
+++ b/src/services/namingService.ts
@@ -26,7 +26,7 @@ export class AzureNamingService {
       this.createShortStageName(stage),
     ].join("-");
 
-    if(includeHash) {
+    if(includeHash && config.provider.resourceGroup) {
       name += `-${md5(config.provider.resourceGroup).substr(0, configConstants.resourceGroupHashLength)}`
     }
 

--- a/src/services/namingService.ts
+++ b/src/services/namingService.ts
@@ -3,6 +3,13 @@ import { Guard } from "../shared/guard"
 import configConstants from "../config";
 import md5 from "md5";
 
+export interface AzureNamingServiceOptions {
+  config: ServerlessAzureConfig;
+  resourceConfig?: ResourceConfig;
+  suffix?: string;
+  includeHash?: boolean;
+}
+
 export class AzureNamingService {
 
   /**
@@ -14,24 +21,28 @@ export class AzureNamingService {
    * @param resourceConfig The serverless resource configuration
    * @param suffix Optional suffix to append on the end of the generated name
    */
-  public static getResourceName(config: ServerlessAzureConfig, resourceConfig?: ResourceConfig, suffix?: string, includeHash: boolean = true) {
-    if (resourceConfig && resourceConfig.name) {
-      return resourceConfig.name;
+  public static getResourceName(options: AzureNamingServiceOptions) {
+    if (options.resourceConfig && options.resourceConfig.name) {
+      return options.resourceConfig.name;
     }
 
-    const { prefix, region, stage } = config.provider
+    if (options.includeHash === undefined) {
+      options.includeHash = true;
+    }
+
+    const { prefix, region, stage } = options.config.provider
     let name = [
       prefix,
       this.createShortAzureRegionName(region),
       this.createShortStageName(stage),
     ].join("-");
 
-    if(includeHash) {
-      name += `-${md5(config.provider.resourceGroup).substr(0, configConstants.resourceGroupHashLength)}`
+    if(options.includeHash) {
+      name += `-${md5(options.config.provider.resourceGroup).substr(0, configConstants.resourceGroupHashLength)}`
     }
 
-    if (suffix) {
-      name += `-${suffix}`;
+    if (options.suffix) {
+      name += `-${options.suffix}`;
     }
 
     return name.toLowerCase();
@@ -50,11 +61,11 @@ export class AzureNamingService {
    * @param forbidden Regex for characters to remove from name. Defaults to non-alpha-numerics
    * @param replaceWith String to replace forbidden characters. Defaults to empty string
    */
-  public static getSafeResourceName(config: ServerlessAzureConfig, maxLength: number, resourceConfig?: ResourceConfig, suffix: string = "", includeHash = false) {
+  public static getSafeResourceName(options: AzureNamingServiceOptions, maxLength: number) {
     const nonAlphaNumeric = /\W+/g;
 
-    if (resourceConfig && resourceConfig.name) {
-      const { name } = resourceConfig;
+    if (options.resourceConfig && options.resourceConfig.name) {
+      const { name } = options.resourceConfig;
 
       if (name.length > maxLength) {
         throw new Error(`Name '${name}' invalid. Should be shorter than ${maxLength} characters`);
@@ -63,14 +74,18 @@ export class AzureNamingService {
       return name.replace(nonAlphaNumeric, "");
     }
 
-    const { prefix, region, stage } = config.provider;
+    if (options.includeHash === undefined) {
+      options.includeHash = true;
+    }
+
+    const { prefix, region, stage } = options.config.provider;
 
     let safePrefix = prefix.replace(nonAlphaNumeric, "");
     const safeRegion = this.createShortAzureRegionName(region);
     let safeStage = this.createShortStageName(stage);
-    let safeSuffix = suffix.replace(nonAlphaNumeric, "");
+    let safeSuffix = options.suffix.replace(nonAlphaNumeric, "");
 
-    const hashLength = (includeHash) ? configConstants.resourceGroupHashLength : 0;
+    const hashLength = (options.includeHash) ? configConstants.resourceGroupHashLength : 0;
     const remaining = maxLength - (safePrefix.length + safeRegion.length + safeStage.length + safeSuffix.length + hashLength);
 
     // Dynamically adjust the substring based on space needed
@@ -85,7 +100,7 @@ export class AzureNamingService {
       safeSuffix = safeSuffix.substr(0, partLength);
     }
 
-    const safeHash = md5(config.provider.resourceGroup).substr(0, hashLength);
+    const safeHash = md5(options.config.provider.resourceGroup).substr(0, hashLength);
 
     const name = [safePrefix, safeRegion, safeStage, safeHash, safeSuffix]
       .join("")
@@ -112,9 +127,15 @@ export class AzureNamingService {
     if (timestamp) {
       maxLength -= timestamp.length + suffix.length;
 
+      const options: AzureNamingServiceOptions = {
+        config,
+        suffix: config.service,
+        includeHash: false,
+      }
+
       const name = (deploymentName)
         ? deploymentName.substr(0, maxLength)
-        : [AzureNamingService.getSafeResourceName(config, maxLength, null, config.service), suffix].join("-");
+        : [AzureNamingService.getSafeResourceName(options, maxLength), suffix].join("-");
 
       return [name, timestamp].join("-");
     }

--- a/src/services/namingService.ts
+++ b/src/services/namingService.ts
@@ -14,7 +14,7 @@ export class AzureNamingService {
    * @param resourceConfig The serverless resource configuration
    * @param suffix Optional suffix to append on the end of the generated name
    */
-  public static getResourceName(config: ServerlessAzureConfig, resourceConfig?: ResourceConfig, suffix?: string) {
+  public static getResourceName(config: ServerlessAzureConfig, resourceConfig?: ResourceConfig, suffix?: string, includeHash: boolean = true) {
     if (resourceConfig && resourceConfig.name) {
       return resourceConfig.name;
     }
@@ -25,6 +25,10 @@ export class AzureNamingService {
       this.createShortAzureRegionName(region),
       this.createShortStageName(stage),
     ].join("-");
+
+    if(includeHash) {
+      name += `-${md5(config.provider.resourceGroup).substr(0, configConstants.resourceGroupHashLength)}`
+    }
 
     if (suffix) {
       name += `-${suffix}`;

--- a/src/services/namingService.ts
+++ b/src/services/namingService.ts
@@ -26,7 +26,7 @@ export class AzureNamingService {
       this.createShortStageName(stage),
     ].join("-");
 
-    if(includeHash && config.provider.resourceGroup) {
+    if(includeHash) {
       name += `-${md5(config.provider.resourceGroup).substr(0, configConstants.resourceGroupHashLength)}`
     }
 

--- a/src/services/namingService.ts
+++ b/src/services/namingService.ts
@@ -8,6 +8,7 @@ export interface AzureNamingServiceOptions {
   resourceConfig?: ResourceConfig;
   suffix?: string;
   includeHash?: boolean;
+  maxLength?: number;
 }
 
 export class AzureNamingService {
@@ -61,14 +62,14 @@ export class AzureNamingService {
    * @param forbidden Regex for characters to remove from name. Defaults to non-alpha-numerics
    * @param replaceWith String to replace forbidden characters. Defaults to empty string
    */
-  public static getSafeResourceName(options: AzureNamingServiceOptions, maxLength: number) {
+  public static getSafeResourceName(options: AzureNamingServiceOptions) {
     const nonAlphaNumeric = /\W+/g;
 
     if (options.resourceConfig && options.resourceConfig.name) {
       const { name } = options.resourceConfig;
 
-      if (name.length > maxLength) {
-        throw new Error(`Name '${name}' invalid. Should be shorter than ${maxLength} characters`);
+      if (name.length > options.maxLength) {
+        throw new Error(`Name '${name}' invalid. Should be shorter than ${options.maxLength} characters`);
       }
 
       return name.replace(nonAlphaNumeric, "");
@@ -86,7 +87,7 @@ export class AzureNamingService {
     let safeSuffix = options.suffix.replace(nonAlphaNumeric, "");
 
     const hashLength = (options.includeHash) ? configConstants.resourceGroupHashLength : 0;
-    const remaining = maxLength - (safePrefix.length + safeRegion.length + safeStage.length + safeSuffix.length + hashLength);
+    const remaining = options.maxLength - (safePrefix.length + safeRegion.length + safeStage.length + safeSuffix.length + hashLength);
 
     // Dynamically adjust the substring based on space needed
     if (remaining < 0) {
@@ -106,8 +107,8 @@ export class AzureNamingService {
       .join("")
       .toLowerCase();
 
-    if (name.length > maxLength) {
-      throw new Error(`Name ${name} is too long. Should be shorter than ${maxLength} characters`)
+    if (name.length > options.maxLength) {
+      throw new Error(`Name ${name} is too long. Should be shorter than ${options.maxLength} characters`)
     }
 
     return name;
@@ -131,11 +132,12 @@ export class AzureNamingService {
         config,
         suffix: config.service,
         includeHash: false,
+        maxLength,
       }
 
       const name = (deploymentName)
         ? deploymentName.substr(0, maxLength)
-        : [AzureNamingService.getSafeResourceName(options, maxLength), suffix].join("-");
+        : [AzureNamingService.getSafeResourceName(options), suffix].join("-");
 
       return [name, timestamp].join("-");
     }


### PR DESCRIPTION
fix: add resource group name hash to resource names

Azure has naming requirements for resources, and for some, requires the names to be unique across azure. Currently on deployments, the plugin doesn't add a more unique hash to the name, so it is possible collisions can occur. By adding the resource group name hash to the resource name, we can avoid this.

AB#1002