### PR TITLE
fix: Create default .azure directory if not present

### DIFF
--- a/src/plugins/login/utils/simpleFileTokenCache.test.ts
+++ b/src/plugins/login/utils/simpleFileTokenCache.test.ts
@@ -2,7 +2,7 @@ import fs from "fs";
 import mockFs from "mock-fs";
 import { MockFactory } from "../../../test/mockFactory";
 import { SimpleFileTokenCache } from "./simpleFileTokenCache";
-// import os from "os";
+import os from "os";
 
 describe("Simple File Token Cache", () => {
   const tokenFilePath = "slsTokenCache.json";
@@ -36,15 +36,14 @@ describe("Simple File Token Cache", () => {
 
   it("Create .azure default directory if it doesn't exist", () => {
     mockFs();
-    // const makeDirSpy = jest.spyOn(fs, "mkdirSync");
-    const mockMkDir = jest.fn(() => {
-      console.log("mocking");
+    const mockMkDir = jest.fn((path) => {
+      return
     });
-    // const mockHomedir = jest.fn(() => {
-    //   return ""
-    // });
+    const mockHomedir = jest.fn(() => {
+      return ""
+    });
     fs.mkdirSync = mockMkDir;
-    // os.homedir = mockHomedir;
+    os.homedir = mockHomedir;
     new SimpleFileTokenCache();
 
     expect(mockMkDir).toBeCalled();

--- a/src/plugins/login/utils/simpleFileTokenCache.test.ts
+++ b/src/plugins/login/utils/simpleFileTokenCache.test.ts
@@ -3,12 +3,15 @@ import mockFs from "mock-fs";
 import { MockFactory } from "../../../test/mockFactory";
 import { SimpleFileTokenCache } from "./simpleFileTokenCache";
 
+import os from "os";
+os.homedir = jest.fn(() => "");
+
 describe("Simple File Token Cache", () => {
   const tokenFilePath = "slsTokenCache.json";
 
   let fileContent = {
     entries: [],
-    subscriptions: [],
+    subscriptions: []
   };
 
   afterEach(() => {
@@ -23,32 +26,31 @@ describe("Simple File Token Cache", () => {
 
     const expected = {
       entries: [],
-      subscriptions: [],
+      subscriptions: []
     };
 
-    expect(writeFileSpy).toBeCalledWith(tokenFilePath, JSON.stringify(expected));
+    expect(writeFileSpy).toBeCalledWith(
+      tokenFilePath,
+      JSON.stringify(expected)
+    );
     writeFileSpy.mockRestore();
   });
 
   it("Create .azure default directory if it doesn't exist", () => {
     mockFs();
     const makeDirSpy = jest.spyOn(fs, "mkdirSync");
-
-    jest.unmock("os");
-    const os = require.requireActual("os");
     
-    os.homedir = jest.fn(() => "./");
     new SimpleFileTokenCache();
 
     expect(makeDirSpy).toBeCalled();
     makeDirSpy.mockRestore();
-  })
+  });
 
   it("Load file on creation if available", () => {
     fileContent.entries = MockFactory.createTestTokenCacheEntries();
 
     mockFs({
-      "slsTokenCache.json": JSON.stringify(fileContent),
+      "slsTokenCache.json": JSON.stringify(fileContent)
     });
 
     const readFileSpy = jest.spyOn(fs, "readFileSync");
@@ -57,7 +59,7 @@ describe("Simple File Token Cache", () => {
     expect(readFileSpy).toBeCalled();
     expect(tokenCache.first()).not.toBeNull();
     readFileSpy.mockRestore();
-  })
+  });
 
   it("Saves to file after token is added", () => {
     mockFs();
@@ -70,11 +72,14 @@ describe("Simple File Token Cache", () => {
 
     const expected = {
       entries: testEntries,
-      subscriptions: [],
+      subscriptions: []
     };
 
     expect(tokenCache.isEmpty()).toBe(false);
-    expect(writeFileSpy).toBeCalledWith(tokenFilePath, JSON.stringify(expected));
+    expect(writeFileSpy).toBeCalledWith(
+      tokenFilePath,
+      JSON.stringify(expected)
+    );
     writeFileSpy.mockRestore();
   });
 
@@ -89,16 +94,19 @@ describe("Simple File Token Cache", () => {
 
     const expected = {
       entries: [],
-      subscriptions: testSubs,
+      subscriptions: testSubs
     };
 
-    expect(writeFileSpy).toBeCalledWith(tokenFilePath, JSON.stringify(expected));
+    expect(writeFileSpy).toBeCalledWith(
+      tokenFilePath,
+      JSON.stringify(expected)
+    );
     writeFileSpy.mockRestore();
   });
 
   it("Doesn't fail adding subs if unable to parse JSON from file", () => {
     mockFs({
-      "slsTokenCache.json": JSON.stringify(""),
+      "slsTokenCache.json": JSON.stringify("")
     });
 
     const writeFileSpy = jest.spyOn(fs, "writeFileSync");
@@ -109,16 +117,19 @@ describe("Simple File Token Cache", () => {
 
     const expected = {
       entries: [],
-      subscriptions: testSubs,
+      subscriptions: testSubs
     };
 
-    expect(writeFileSpy).toBeCalledWith(tokenFilePath, JSON.stringify(expected));
+    expect(writeFileSpy).toBeCalledWith(
+      tokenFilePath,
+      JSON.stringify(expected)
+    );
     writeFileSpy.mockRestore();
   });
 
   it("Doesn't fail removing entries if unable to parse JSON from file", () => {
     mockFs({
-      "slsTokenCache.json": JSON.stringify(""),
+      "slsTokenCache.json": JSON.stringify("")
     });
 
     const writeFileSpy = jest.spyOn(fs, "writeFileSync");
@@ -127,20 +138,23 @@ describe("Simple File Token Cache", () => {
     const testEntries = MockFactory.createTestTokenCacheEntries();
 
     testFileCache.addSubs(testSubs);
-    testFileCache.remove(testEntries)
+    testFileCache.remove(testEntries);
 
     const expected = {
       entries: [],
-      subscriptions: testSubs,
+      subscriptions: testSubs
     };
 
-    expect(writeFileSpy).toBeCalledWith(tokenFilePath, JSON.stringify(expected));
+    expect(writeFileSpy).toBeCalledWith(
+      tokenFilePath,
+      JSON.stringify(expected)
+    );
     writeFileSpy.mockRestore();
   });
 
   it("Doesn't fail find if unable to parse JSON from file", () => {
     mockFs({
-      "slsTokenCache.json": JSON.stringify(""),
+      "slsTokenCache.json": JSON.stringify("")
     });
 
     const testFileCache = new SimpleFileTokenCache(tokenFilePath);
@@ -148,7 +162,7 @@ describe("Simple File Token Cache", () => {
 
     testFileCache.addSubs(testSubs);
     const cb = jest.fn();
-    const result = testFileCache.find({key: "value"}, cb);
+    const result = testFileCache.find({ key: "value" }, cb);
 
     expect(cb).toBeCalledWith(null, result);
     expect(result).toEqual([]);

--- a/src/plugins/login/utils/simpleFileTokenCache.test.ts
+++ b/src/plugins/login/utils/simpleFileTokenCache.test.ts
@@ -30,6 +30,15 @@ describe("Simple File Token Cache", () => {
     writeFileSpy.mockRestore();
   });
 
+  it("Create .azure default directory if it doesn't exist", () => {
+    mockFs();
+    const makeDirSpy = jest.spyOn(fs, "mkdirSync");
+    new SimpleFileTokenCache();
+
+    expect(makeDirSpy).toBeCalled();
+    makeDirSpy.mockRestore();
+  })
+
   it("Load file on creation if available", () => {
     fileContent.entries = MockFactory.createTestTokenCacheEntries();
 

--- a/src/plugins/login/utils/simpleFileTokenCache.test.ts
+++ b/src/plugins/login/utils/simpleFileTokenCache.test.ts
@@ -33,6 +33,11 @@ describe("Simple File Token Cache", () => {
   it("Create .azure default directory if it doesn't exist", () => {
     mockFs();
     const makeDirSpy = jest.spyOn(fs, "mkdirSync");
+
+    jest.unmock("os");
+    const os = require.requireActual("os");
+    
+    os.homedir = jest.fn(() => "./");
     new SimpleFileTokenCache();
 
     expect(makeDirSpy).toBeCalled();

--- a/src/plugins/login/utils/simpleFileTokenCache.test.ts
+++ b/src/plugins/login/utils/simpleFileTokenCache.test.ts
@@ -48,6 +48,7 @@ describe("Simple File Token Cache", () => {
 
     expect(mockMkDir).toBeCalled();
     mockMkDir.mockRestore();
+    mockHomedir.mockRestore();
   });
 
   it("Load file on creation if available", () => {

--- a/src/plugins/login/utils/simpleFileTokenCache.test.ts
+++ b/src/plugins/login/utils/simpleFileTokenCache.test.ts
@@ -2,9 +2,7 @@ import fs from "fs";
 import mockFs from "mock-fs";
 import { MockFactory } from "../../../test/mockFactory";
 import { SimpleFileTokenCache } from "./simpleFileTokenCache";
-
-import os from "os";
-os.homedir = jest.fn(() => "");
+// import os from "os";
 
 describe("Simple File Token Cache", () => {
   const tokenFilePath = "slsTokenCache.json";
@@ -38,12 +36,19 @@ describe("Simple File Token Cache", () => {
 
   it("Create .azure default directory if it doesn't exist", () => {
     mockFs();
-    const makeDirSpy = jest.spyOn(fs, "mkdirSync");
-    
+    // const makeDirSpy = jest.spyOn(fs, "mkdirSync");
+    const mockMkDir = jest.fn(() => {
+      console.log("mocking");
+    });
+    // const mockHomedir = jest.fn(() => {
+    //   return ""
+    // });
+    fs.mkdirSync = mockMkDir;
+    // os.homedir = mockHomedir;
     new SimpleFileTokenCache();
 
-    expect(makeDirSpy).toBeCalled();
-    makeDirSpy.mockRestore();
+    expect(mockMkDir).toBeCalled();
+    mockMkDir.mockRestore();
   });
 
   it("Load file on creation if available", () => {

--- a/src/plugins/login/utils/simpleFileTokenCache.ts
+++ b/src/plugins/login/utils/simpleFileTokenCache.ts
@@ -12,7 +12,7 @@ export class SimpleFileTokenCache implements adal.TokenCache {
 
   public constructor(private tokenPath: string = DEFAULT_SLS_TOKEN_FILE) {
     if(tokenPath === DEFAULT_SLS_TOKEN_FILE && !fs.existsSync(CONFIG_DIRECTORY)) {
-      fs.mkdirSync(CONFIG_DIRECTORY);
+      fs.mkdirSync(CONFIG_DIRECTORY, {recursive: true});
     }
     this.load();
   }

--- a/src/plugins/login/utils/simpleFileTokenCache.ts
+++ b/src/plugins/login/utils/simpleFileTokenCache.ts
@@ -3,7 +3,7 @@ import path from "path";
 import os from "os";
 import * as adal from "adal-node";
 
-const CONFIG_DIRECTORY = path.join(os.homedir(), ".azure");
+let CONFIG_DIRECTORY = path.join(os.homedir(), ".azure");
 const DEFAULT_SLS_TOKEN_FILE = path.join(CONFIG_DIRECTORY, "slsTokenCache.json");
 
 export class SimpleFileTokenCache implements adal.TokenCache {
@@ -12,6 +12,8 @@ export class SimpleFileTokenCache implements adal.TokenCache {
 
   public constructor(private tokenPath: string = DEFAULT_SLS_TOKEN_FILE) {
     if(tokenPath === DEFAULT_SLS_TOKEN_FILE && !fs.existsSync(CONFIG_DIRECTORY)) {
+      CONFIG_DIRECTORY = path.join(os.homedir(), ".azure");
+      this.tokenPath = CONFIG_DIRECTORY;
       fs.mkdirSync(CONFIG_DIRECTORY);
     }
     this.load();

--- a/src/plugins/login/utils/simpleFileTokenCache.ts
+++ b/src/plugins/login/utils/simpleFileTokenCache.ts
@@ -11,6 +11,9 @@ export class SimpleFileTokenCache implements adal.TokenCache {
   private subscriptions: any[] = [];
 
   public constructor(private tokenPath: string = DEFAULT_SLS_TOKEN_FILE) {
+    if(tokenPath === DEFAULT_SLS_TOKEN_FILE && !fs.existsSync(CONFIG_DIRECTORY)) {
+      fs.mkdirSync(CONFIG_DIRECTORY);
+    }
     this.load();
   }
 

--- a/src/plugins/login/utils/simpleFileTokenCache.ts
+++ b/src/plugins/login/utils/simpleFileTokenCache.ts
@@ -12,7 +12,7 @@ export class SimpleFileTokenCache implements adal.TokenCache {
 
   public constructor(private tokenPath: string = DEFAULT_SLS_TOKEN_FILE) {
     if(tokenPath === DEFAULT_SLS_TOKEN_FILE && !fs.existsSync(CONFIG_DIRECTORY)) {
-      fs.mkdirSync(CONFIG_DIRECTORY, {recursive: true});
+      fs.mkdirSync(CONFIG_DIRECTORY);
     }
     this.load();
   }

--- a/src/services/azureKeyVaultService.test.ts
+++ b/src/services/azureKeyVaultService.test.ts
@@ -31,7 +31,6 @@ describe("Azure Key Vault Service", () => {
     }) as any;
 
     FunctionAppService.prototype.get = jest.fn(() => {
-      console.log("testing");
       return {
         identity: {
           tenantId: "tid",


### PR DESCRIPTION
fix: Create default .azure directory if not present

The pluging currently saves credentials from interactive login in the .azure directory by default. If the user doesn't have a .azure directory, current;y the plugin hits an error. This fix checks to make sure the .azure directory exists and creates it if not. 

Closes #317 