### PR TITLE
fix: Fix failing invoke with data path

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,19 @@ $ sls invoke -f <functionName>
 After deploying template function app, run
 
 ```bash
-$ sls invoke -f hello '{"name": "Azure"}'
+$ sls invoke -f hello -d '{"name": "Azure"}'
+```
+
+If you have a JSON object in a file, you could run
+
+```bash
+$ sls invoke -f hello -p data.json
+```
+
+If you have your service running locally (in another terminal), you can run:
+
+```bash
+$ sls invoke local -f hello -p data.json
 ```
 
 ### Roll Back Your Function App

--- a/src/plugins/invoke/azureInvokePlugin.test.ts
+++ b/src/plugins/invoke/azureInvokePlugin.test.ts
@@ -50,14 +50,17 @@ describe("Azure Invoke Plugin", () => {
     options["function"] = "testApp";
     options["path"] = "testFile.json";
     options["method"] = "GET";
-    const plugin = new AzureInvokePlugin(sls, options);
+    const plugin = new AzureInvokePlugin(sls, {
+      function: "testApp",
+      path: "testFile.json",
+    } as any);
     await invokeHook(plugin, "invoke:invoke");
     expect(invoke).toBeCalledWith(options["method"], options["function"], fileContent);
     expect(sls.cli.log).toBeCalledWith(JSON.stringify(expectedResult.data));
 
   });
 
-  it("calls the invoke hook with file path", async () => {
+  it("fails when data file path does not exist", async () => {
     const invoke = jest.fn();
     InvokeService.prototype.invoke = invoke;
     const sls = MockFactory.createTestServerless();
@@ -65,7 +68,11 @@ describe("Azure Invoke Plugin", () => {
     options["function"] = "testApp";
     options["path"] = "notExist.json";
     options["method"] = "GET";
-    expect(() => new AzureInvokePlugin(sls, options)).toThrow();
+    const plugin = new AzureInvokePlugin(sls, {
+      function: "testApp",
+      path: "notExist.json",
+    } as any);
+    await expect(invokeHook(plugin, "invoke:invoke")).rejects.toThrow();
   });
 
   it("Function invoked with no data", async () => {


### PR DESCRIPTION
Moves data path initialization outside of the constructor and does not replace the `data` property within options. Instead, passes the contents of the file path to the invoke service.

Fixes #320 