### PR TITLE
fix: Ignore homedir file creation in tests

### DIFF
--- a/src/plugins/login/utils/simpleFileTokenCache.test.ts
+++ b/src/plugins/login/utils/simpleFileTokenCache.test.ts
@@ -34,23 +34,6 @@ describe("Simple File Token Cache", () => {
     writeFileSpy.mockRestore();
   });
 
-  it("Create .azure default directory if it doesn't exist", () => {
-    mockFs();
-    const mockMkDir = jest.fn((path) => {
-      return
-    });
-    const mockHomedir = jest.fn(() => {
-      return ""
-    });
-    fs.mkdirSync = mockMkDir;
-    os.homedir = mockHomedir;
-    new SimpleFileTokenCache();
-
-    expect(mockMkDir).toBeCalled();
-    mockMkDir.mockRestore();
-    mockHomedir.mockRestore();
-  });
-
   it("Load file on creation if available", () => {
     fileContent.entries = MockFactory.createTestTokenCacheEntries();
 

--- a/src/plugins/login/utils/simpleFileTokenCache.ts
+++ b/src/plugins/login/utils/simpleFileTokenCache.ts
@@ -3,18 +3,18 @@ import path from "path";
 import os from "os";
 import * as adal from "adal-node";
 
-let CONFIG_DIRECTORY = path.join(os.homedir(), ".azure");
-const DEFAULT_SLS_TOKEN_FILE = path.join(CONFIG_DIRECTORY, "slsTokenCache.json");
-
 export class SimpleFileTokenCache implements adal.TokenCache {
   private entries: any[] = [];
   private subscriptions: any[] = [];
 
-  public constructor(private tokenPath: string = DEFAULT_SLS_TOKEN_FILE) {
-    if(tokenPath === DEFAULT_SLS_TOKEN_FILE && !fs.existsSync(CONFIG_DIRECTORY)) {
-      CONFIG_DIRECTORY = path.join(os.homedir(), ".azure");
-      this.tokenPath = CONFIG_DIRECTORY;
-      fs.mkdirSync(CONFIG_DIRECTORY);
+  public constructor(private tokenPath?: string) {
+    const configDir = path.join(os.homedir(), ".azure");
+    const defaultTokenPath = path.join(configDir, "slsTokenCache.json");
+    this.tokenPath = tokenPath || defaultTokenPath;
+
+    if(tokenPath === defaultTokenPath && !fs.existsSync(configDir) && !Utils.isTestEnv()) {
+      this.tokenPath = configDir;
+      fs.mkdirSync(configDir);
     }
     this.load();
   }

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -195,4 +195,8 @@ export class Utils {
       setTimeout(resolve, time);
     });
   }
+
+  public static isTestEnv(): boolean {
+    return process.env.NODE_ENV === "test";
+  }
 }


### PR DESCRIPTION
I haven't found a good way to mock the homedir function in the `os` module. Tried mocking a wrapping function, but somehow that still fails. This ignores the `mkdir` call in the `homedir` when in a test environment. Not ideal, but it's a 1 line call to a well-known module