### PR TITLE
feat: ConfigService for centralizing configuration and simplifying BaseService

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,35 @@
+{
+    "version": "0.2.0",
+    "configurations": [
+      {
+        "type": "node",
+        "request": "launch",
+        "name": "Jest All",
+        "program": "${workspaceFolder}/node_modules/.bin/jest",
+        "args": ["--runInBand"],
+        "console": "integratedTerminal",
+        "internalConsoleOptions": "neverOpen",
+        "disableOptimisticBPs": true,
+        "windows": {
+          "program": "${workspaceFolder}/node_modules/jest/bin/jest",
+        }
+      },
+      {
+        "type": "node",
+        "request": "launch",
+        "name": "Jest Current File",
+        "program": "${workspaceFolder}/node_modules/.bin/jest",
+        "args": [
+          "${fileBasenameNoExtension}",
+          "--config",
+          "jest.config.js"
+        ],
+        "console": "integratedTerminal",
+        "internalConsoleOptions": "neverOpen",
+        "disableOptimisticBPs": true,
+        "windows": {
+          "program": "${workspaceFolder}/node_modules/jest/bin/jest",
+        }
+      }
+    ]
+  }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-azure-functions",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Provider plugin for the Serverless Framework v1.x which adds support for Azure Functions.",
   "license": "MIT",
   "main": "./lib/index.js",

--- a/src/config.ts
+++ b/src/config.ts
@@ -34,7 +34,13 @@ export const configConstants = {
   scmVfsPath: "/api/vfs/site/wwwroot/",
   scmZipDeployApiPath: "/api/zipdeploy",
   resourceGroupHashLength: 6,
-  defaultLocalPort: 7071,
+  defaults: {
+    awsRegion: "us-east-1",
+    region: "westus",
+    stage: "dev",
+    prefix: "sls",
+    localPort: 7071,
+  },
 };
 
 export default configConstants;

--- a/src/models/serverless.ts
+++ b/src/models/serverless.ts
@@ -35,6 +35,8 @@ export interface ServerlessAzureProvider {
   stage: string;
   name: string;
   subscriptionId?: string;
+  tenantId?: string;
+  appId?: string;
   environment?: {
     [key: string]: any;
   };

--- a/src/services/apimService.test.ts
+++ b/src/services/apimService.test.ts
@@ -70,8 +70,8 @@ describe("APIM Service", () => {
     const apimConfigName = MockFactory.createTestApimConfig(true);
     (serverless.service.provider as any).apim = apimConfigName;
 
-    const service = new ApimService(serverless);
-    const expectedRegionName = AzureNamingService.createShortAzureRegionName(service.getRegion());
+    new ApimService(serverless);
+    const expectedRegionName = AzureNamingService.createShortAzureRegionName(serverless.service.provider.region);
     expect(apimConfigName.name.includes(expectedRegionName)).toBeTruthy();
   });
 

--- a/src/services/configService.test.ts
+++ b/src/services/configService.test.ts
@@ -1,0 +1,166 @@
+import { ConfigService } from "./configService";
+import Serverless from "serverless";
+import { MockFactory } from "../test/mockFactory";
+import { ServerlessAzureConfig } from "../models/serverless";
+import configConstants from "../config";
+import { AzureNamingService } from "./namingService";
+
+describe("Config Service", () => {
+  const serviceName = "my-custom-service"
+
+  let serverless: Serverless;
+
+  beforeEach(() => {
+    serverless = MockFactory.createTestServerless();
+    const config = (serverless.service as any as ServerlessAzureConfig);
+    config.service = serviceName;
+
+    delete config.provider.resourceGroup;
+    delete config.provider.region;
+    delete config.provider.stage;
+    delete config.provider.prefix;
+  });
+
+  describe("Configurable Variables", () => {
+
+    it("returns default values if not specified", () => {
+      const service = new ConfigService(serverless, {} as any);
+      const { prefix, region, stage } = configConstants.defaults;
+      expect(service.getPrefix()).toEqual(prefix);
+      expect(service.getStage()).toEqual(stage);
+      expect(service.getRegion()).toEqual(region);
+    });
+
+    it("use prefix from the CLI over the SLS yml config", () => {
+      const prefix = "prefix";
+      const config = (serverless.service as any as ServerlessAzureConfig);
+      delete config.provider.resourceGroup;
+      config.provider.prefix = "not the prefix";    
+      expect(serverless.service.provider["prefix"]).not.toEqual(prefix);
+      const service = new ConfigService(serverless, { prefix } as any);
+      expect(service.getPrefix()).toEqual(prefix);
+      expect(service.getResourceGroupName()).toEqual(`${prefix}-wus-dev-${serviceName}-rg`);
+    });
+
+    it("use region name from the CLI over the SLS yml config", () => {
+      const region = "East US";
+      const config = (serverless.service as any as ServerlessAzureConfig);
+      delete config.provider.resourceGroup;
+
+      expect(serverless.service.provider.region).not.toEqual(region);
+      const service = new ConfigService(serverless, { region } as any);
+      expect(service.getRegion()).toEqual(region);
+      expect(service.getResourceGroupName()).toEqual(`sls-eus-dev-${serviceName}-rg`);
+    });
+
+    it("use stage name from the CLI over the SLS yml config", () => {
+      const stage = "test";
+      expect(serverless.service.provider.stage).not.toEqual(stage);
+      const service = new ConfigService(serverless, { stage } as any);
+      expect(service.getStage()).toEqual(stage);
+      expect(service.getResourceGroupName()).toEqual(`sls-wus-${stage}-${serviceName}-rg`);
+    });
+
+    it("use the resource group name from the CLI over the SLS yml config", () => {
+      const resourceGroup = "resourceGroup";
+      const config = (serverless.service as any as ServerlessAzureConfig);
+      config.provider.resourceGroup = "not the resource group";
+      expect(serverless.service.provider["resourceGroup"]).not.toEqual(resourceGroup);
+      const service = new ConfigService(serverless, { resourceGroup } as any);
+      expect(service.getResourceGroupName()).toEqual(resourceGroup);
+    });
+
+    it("use the prefix defined in SLS yml config", () => {
+      const expectedPrefix = "testPrefix"
+      serverless.service.provider["prefix"] = expectedPrefix;
+      const service = new ConfigService(serverless, { } as any);
+      expect(service.getPrefix()).toEqual(expectedPrefix);
+    });
+
+    it("use region from SLS yml config", () => {
+      const expectedRegion = "eastus2"
+      serverless.service.provider["region"] = expectedRegion;
+      const service = new ConfigService(serverless, { } as any);
+      expect(service.getRegion()).toEqual(expectedRegion);
+    });
+
+    it("use stage name from SLS yml config", () => {
+      const expectedStage = "testStage"
+      serverless.service.provider["stage"] = expectedStage;
+      const service = new ConfigService(serverless, { } as any);
+      expect(service.getStage()).toEqual(expectedStage);
+    });
+
+    it("use the resource group name from SLS yml config", () => {
+      const service = new ConfigService(serverless, { } as any);
+      expect(service.getResourceGroupName()).toEqual(serverless.service.provider["resourceGroup"]);
+    });
+
+    it("use location property as region if region not set", () => {
+      const slsService = MockFactory.createTestService();
+      delete slsService.provider.region;
+      const location = "East US";
+      slsService.provider["location"] = location;
+  
+      const sls = MockFactory.createTestServerless({
+        service: slsService
+      });
+  
+      const service = new ConfigService(sls, {} as any);
+      expect(service.getRegion()).toEqual(location);
+    });
+  
+    it("Generates resource group from convention when NOT defined in sls yaml", () => {
+      serverless.service.provider["resourceGroup"] = null;
+      const service = new ConfigService(serverless, { } as any);
+      const actualResourceGroupName = service.getResourceGroupName();
+      const expectedRegion = AzureNamingService.createShortAzureRegionName(service.getRegion());
+      const expectedStage = AzureNamingService.createShortStageName(service.getStage());
+      const expectedResourceGroupName = `sls-${expectedRegion}-${expectedStage}-${serverless.service["service"]}-rg`;
+      expect(actualResourceGroupName).toEqual(expectedResourceGroupName);
+    });
+  });
+  
+  describe("Service Principal Configuration", () => {
+    
+    const cliSubscriptionId = "cli sub id";
+    const envVarSubscriptionId = "env var sub id";
+    const configSubscriptionId = "config sub id";
+    const loginResultSubscriptionId = "ABC123";
+  
+    it("use subscription ID from the CLI", () => {
+      process.env.AZURE_SUBSCRIPTION_ID = envVarSubscriptionId;
+      serverless.service.provider["subscriptionId"] = configSubscriptionId;
+      serverless.variables["subscriptionId"] = loginResultSubscriptionId
+      const service = new ConfigService(serverless, { subscriptionId: cliSubscriptionId } as any);
+      expect(service.getSubscriptionId()).toEqual(cliSubscriptionId);
+      expect(serverless.service.provider["subscriptionId"]).toEqual(cliSubscriptionId);
+    });
+  
+    it("use subscription ID from environment variable", () => {
+      process.env.AZURE_SUBSCRIPTION_ID = envVarSubscriptionId;
+      serverless.service.provider["subscriptionId"] = configSubscriptionId;
+      serverless.variables["subscriptionId"] = loginResultSubscriptionId
+      const service = new ConfigService(serverless, { } as any);
+      expect(service.getSubscriptionId()).toEqual(envVarSubscriptionId);
+      expect(serverless.service.provider["subscriptionId"]).toEqual(envVarSubscriptionId);
+    });
+  
+    it("use subscription ID from config", () => {
+      delete process.env.AZURE_SUBSCRIPTION_ID;
+      serverless.service.provider["subscriptionId"] = configSubscriptionId;
+      serverless.variables["subscriptionId"] = loginResultSubscriptionId
+      const service = new ConfigService(serverless, { } as any);
+      expect(service.getSubscriptionId()).toEqual(configSubscriptionId);
+      expect(serverless.service.provider["subscriptionId"]).toEqual(configSubscriptionId);
+    });
+  
+    it("use subscription ID from login result", () => {
+      delete process.env.AZURE_SUBSCRIPTION_ID;
+      serverless.variables["subscriptionId"] = loginResultSubscriptionId
+      const service = new ConfigService(serverless, { } as any);
+      expect(service.getSubscriptionId()).toEqual(loginResultSubscriptionId);
+      expect(serverless.service.provider["subscriptionId"]).toEqual(loginResultSubscriptionId);
+    });
+  });
+});

--- a/src/services/configService.test.ts
+++ b/src/services/configService.test.ts
@@ -22,7 +22,6 @@ describe("Config Service", () => {
   });
 
   describe("Configurable Variables", () => {
-
     it("returns default values if not specified", () => {
       const service = new ConfigService(serverless, {} as any);
       const { prefix, region, stage } = configConstants.defaults;
@@ -122,7 +121,6 @@ describe("Config Service", () => {
   });
   
   describe("Service Principal Configuration", () => {
-    
     const cliSubscriptionId = "cli sub id";
     const envVarSubscriptionId = "env var sub id";
     const configSubscriptionId = "config sub id";

--- a/src/services/configService.ts
+++ b/src/services/configService.ts
@@ -1,0 +1,210 @@
+import Serverless from "serverless";
+import Service from "serverless/classes/Service";
+import configConstants from "../config";
+import { ServerlessAzureConfig, ServerlessAzureFunctionConfig } from "../models/serverless";
+import { constants } from "../shared/constants";
+import { Utils } from "../shared/utils";
+import { AzureNamingService, AzureNamingServiceOptions } from "./namingService";
+
+/**
+ * Handles all Service Configuration
+ */
+export class ConfigService {
+
+  /** Configuration for service */
+  private config: ServerlessAzureConfig;
+
+  public constructor(private serverless: Serverless, private options: Serverless.Options) {
+    this.config = this.initializeConfig(serverless.service);
+  }
+
+  /**
+   * Get Azure Provider Configuration
+   */
+  public getConfig(): ServerlessAzureConfig {
+    return this.config;
+  }
+
+  /**
+   * Name of Azure Region for deployment
+   */
+  public getRegion(): string {
+    return this.config.provider.region;
+  }
+
+  /**
+   * Name of current deployment stage
+   */
+  public getStage(): string {
+    return this.config.provider.stage;
+  }
+
+  /**
+   * Prefix for service
+   */
+  public getPrefix(): string {
+    return this.config.provider.prefix;
+  }
+
+  /**
+   * Name of current resource group
+   */
+  public getResourceGroupName(): string {
+    return this.config.provider.resourceGroup;
+  }
+
+  /**
+   * Azure Subscription ID
+   */
+  public getSubscriptionId(): string {
+    return this.config.provider.subscriptionId;
+  }
+
+  /**
+   * Name of current deployment
+   */
+  public getDeploymentName(): string {
+    return AzureNamingService.getDeploymentName(
+      this.config,
+      (this.config.provider.deployment.rollback) ? `t${this.getTimestamp()}` : null
+    )
+  }
+
+  /**
+   * Get rollback-configured artifact name. Contains `-t{timestamp}`
+   * Takes name of deployment and replaces `rg-deployment` or `deployment` with `artifact`
+   */
+  public getArtifactName(deploymentName?: string): string {
+    deploymentName = deploymentName || this.getDeploymentName();
+    const { deployment, artifact } = configConstants.naming.suffix;
+    return `${deploymentName
+      .replace(`rg-${deployment}`, artifact)
+      .replace(deployment, artifact)}.zip`
+  }
+
+  /**
+   * Function configuration from serverless.yml
+   */
+  public getFunctionConfig(): { [functionName: string]: ServerlessAzureFunctionConfig } {
+    return this.config.functions;
+  }
+
+  /**
+   * Name of file containing serverless config
+   */
+  public getConfigFile(): string {
+    return this.getOption("config", "serverless.yml");
+  }
+
+  /**
+   * Name of Function App Service
+   */
+  public getServiceName(): string {
+    return this.config.service;
+  }
+
+  /**
+   * Set any default values required for service
+   * @param config Current Serverless configuration
+   */
+  private setDefaultValues(config: ServerlessAzureConfig) {
+    const { awsRegion, region, stage, prefix } = configConstants.defaults;
+    const providerRegion = config.provider.region;
+
+    if (!providerRegion || providerRegion === awsRegion) {
+      config.provider.region = this.serverless.service.provider["location"] || region;
+    }
+ 
+    if (!config.provider.stage) {
+      config.provider.stage = stage;
+    }
+
+    if (!config.provider.prefix) {
+      config.provider.prefix = prefix;
+    }
+  }
+
+  /**
+   * Overwrite values for resourceGroup, prefix, region and stage
+   * in config if passed through CLI
+   */
+  private initializeConfig(service: Service): ServerlessAzureConfig {
+    const config: ServerlessAzureConfig = service as any;
+    this.setDefaultValues(config);
+
+    const {
+      prefix,
+      region,
+      stage,
+      subscriptionId,
+      tenantId,
+      appId,
+      deployment
+    } = config.provider;
+
+    const options: AzureNamingServiceOptions = {
+      config: config,
+      suffix: `${config.service}-rg`,
+      includeHash: false,
+    }
+
+    config.provider = {
+      ...config.provider,
+      prefix: this.getOption("prefix") || prefix,
+      stage: this.getOption("stage") || stage,
+      region: this.getOption("region") || region,
+      subscriptionId: this.getOption(constants.variableKeys.subscriptionId)
+        || process.env.AZURE_SUBSCRIPTION_ID
+        || subscriptionId
+        || this.serverless.variables[constants.variableKeys.subscriptionId],
+      tenantId: this.getOption(constants.variableKeys.tenantId)
+        || process.env.AZURE_TENANT_ID
+        || tenantId,
+      appId: this.getOption(constants.variableKeys.appId)
+        || process.env.AZURE_CLIENT_ID
+        || appId
+    }
+    config.provider.resourceGroup = (
+      this.getOption("resourceGroup", config.provider.resourceGroup)
+    ) || AzureNamingService.getResourceName(options);
+
+    config.provider.deployment = {
+      ...configConstants.deploymentConfig,
+      ...deployment
+    }
+
+    return config;
+  }
+
+  /**
+   * Get timestamp from `packageTimestamp` serverless variable
+   * If not set, create timestamp, set variable and return timestamp
+   */
+  private getTimestamp(): number {
+    const key = constants.variableKeys.packageTimestamp
+    let timestamp = +this.getVariable(key);
+    if (!timestamp) {
+      timestamp = Date.now();
+      this.serverless.variables[key] = timestamp;
+    }
+    return timestamp;
+  }
+
+  /**
+   * Get value of option from Serverless CLI
+   * @param key Key of option
+   * @param defaultValue Default value if key not found in options object
+   */
+  protected getOption(key: string, defaultValue?: any) {
+    return Utils.get(this.options, key, defaultValue);
+  }
+
+  /**
+   * Get variable value from Serverless variables
+   * @param key Key for variable
+   * @param defaultValue Default value if key not found in variable object
+   */
+  protected getVariable(key: string, defaultValue?: any) {
+    return Utils.get(this.serverless.variables, key, defaultValue);
+  }
+}

--- a/src/services/funcService.ts
+++ b/src/services/funcService.ts
@@ -44,7 +44,7 @@ export class FuncService extends BaseService {
   }
 
   private exists(functionName: string) {
-    return (functionName in this.slsFunctions());
+    return (functionName in this.configService.getFunctionConfig());
   }
 
   private createHandler(functionName: string) {
@@ -52,26 +52,26 @@ export class FuncService extends BaseService {
   }
 
   private addToServerlessYml(functionName: string) {
-    const functions = this.slsFunctions();
+    const functions = this.configService.getFunctionConfig();
     functions[functionName] = this.getFunctionSlsObject(functionName)
     this.updateFunctionsYml(functions)
   }
 
   private removeFromServerlessYml(functionName: string) {
-    const functions = this.slsFunctions();
+    const functions = this.configService.getFunctionConfig();
     delete functions[functionName];
     this.updateFunctionsYml(functions)
   }
 
   private getServerlessYml() {
-    return this.serverless.utils.readFileSync(this.slsConfigFile());
+    return this.serverless.utils.readFileSync(this.configService.getConfigFile());
   }
 
   private updateFunctionsYml(functionYml: any) {
     const serverlessYml = this.getServerlessYml();
     serverlessYml["functions"] = functionYml;
     this.serverless.utils.writeFileSync(
-      this.slsConfigFile(),
+      this.configService.getConfigFile(),
       yaml.dump(serverlessYml)
     );
   }

--- a/src/services/functionAppService.ts
+++ b/src/services/functionAppService.ts
@@ -155,12 +155,12 @@ export class FunctionAppService extends BaseService {
 
     const functionZipFile = this.getFunctionZipFile();
 
-    if (this.deploymentConfig.runFromBlobUrl) {
+    if (this.config.provider.deployment.runFromBlobUrl) {
       this.log("Updating function app setting to run from external package...");
       await this.uploadZippedArtifactToBlobStorage(functionZipFile);
 
       const sasUrl = await this.blobService.generateBlobSasTokenUrl(
-        this.deploymentConfig.container,
+        this.config.provider.deployment.container,
         this.artifactName
       );
 
@@ -250,6 +250,10 @@ export class FunctionAppService extends BaseService {
     return functionZipFile;
   }
 
+  public getDeploymentName(): string {
+    return this.configService.getDeploymentName();
+  }
+
   public async updateFunctionAppSetting(functionApp: Site, setting: string, value: string) {
     const { properties } = await this.webClient.webApps.listApplicationSettings(this.resourceGroup, functionApp.name);
     properties[setting] = value;
@@ -261,10 +265,10 @@ export class FunctionAppService extends BaseService {
    */
   private async uploadZippedArtifactToBlobStorage(functionZipFile: string): Promise<void> {
     await this.blobService.initialize();
-    await this.blobService.createContainerIfNotExists(this.deploymentConfig.container);
+    await this.blobService.createContainerIfNotExists(this.config.provider.deployment.container);
     await this.blobService.uploadFile(
       functionZipFile,
-      this.deploymentConfig.container,
+      this.config.provider.deployment.container,
       this.artifactName,
     );
   }

--- a/src/services/invokeService.test.ts
+++ b/src/services/invokeService.test.ts
@@ -20,7 +20,7 @@ describe("Invoke Service ", () => {
   const functionName = "hello";
   const urlPOST = `http://${app.defaultHostName}/api/${functionName}`;
   const urlGET = `http://${app.defaultHostName}/api/${functionName}?name%3D${testData}`;
-  const localUrl = `http://localhost:${configConstants.defaultLocalPort}/api/${functionName}`
+  const localUrl = `http://localhost:${configConstants.defaults.localPort}/api/${functionName}`
   let masterKey: string;
   let sls = MockFactory.createTestServerless();
   let options = {

--- a/src/services/invokeService.ts
+++ b/src/services/invokeService.ts
@@ -24,7 +24,7 @@ export class InvokeService extends BaseService {
    */
   public async invoke(method: string, functionName: string, data?: any){
 
-    const functionObject = this.slsFunctions()[functionName];
+    const functionObject = this.configService.getFunctionConfig()[functionName];
     /* accesses the admin key */
     if (!functionObject) {
       this.serverless.cli.log(`Function ${functionName} does not exist`);
@@ -63,7 +63,7 @@ export class InvokeService extends BaseService {
   }
 
   private getLocalHost() {
-    return `http://localhost:${this.getOption("port", configConstants.defaultLocalPort)}`
+    return `http://localhost:${this.getOption("port", configConstants.defaults.localPort)}`
   }
 
   private getConfiguredFunctionRoute(functionName: string) {

--- a/src/services/loginService.ts
+++ b/src/services/loginService.ts
@@ -27,7 +27,7 @@ export class AzureLoginService extends BaseService {
    * @param options Options for different authentication methods
    */
   public async login(options?: AzureTokenCredentialsOptions | InteractiveLoginOptions): Promise<AuthResponse> {
-    const subscriptionId = this.getSubscriptionId();
+    const subscriptionId = this.configService.getSubscriptionId();
     const clientId = process.env.AZURE_CLIENT_ID;
     const secret = process.env.AZURE_CLIENT_SECRET;
     const tenantId = process.env.AZURE_TENANT_ID;
@@ -56,5 +56,9 @@ export class AzureLoginService extends BaseService {
 
   public async servicePrincipalLogin(clientId: string, secret: string, tenantId: string, options: AzureTokenCredentialsOptions): Promise<AuthResponse> {
     return await loginWithServicePrincipalSecretWithAuthResponse(clientId, secret, tenantId, options);
+  }
+
+  public getSubscriptionId() {
+    return this.configService.getSubscriptionId();
   }
 }

--- a/src/services/packageService.ts
+++ b/src/services/packageService.ts
@@ -93,7 +93,7 @@ export class PackageService extends BaseService {
     const functionJSON = functionMetadata.params.functionsJson;
     functionJSON.entryPoint = functionMetadata.entryPoint;
     functionJSON.scriptFile = functionMetadata.handlerPath;
-    const functionObject = this.slsFunctions()[functionName];
+    const functionObject = this.configService.getFunctionConfig()[functionName];
     const bindingAzureSettings = Utils.getIncomingBindingConfig(functionObject)["x-azure-settings"];
 
     if (bindingAzureSettings.route) {

--- a/src/services/resourceService.ts
+++ b/src/services/resourceService.ts
@@ -58,7 +58,7 @@ export class ResourceService extends BaseService {
   public async listDeployments(): Promise<string> {
     const deployments = await this.getDeployments()
     if (!deployments || deployments.length === 0) {
-      this.log(`No deployments found for resource group '${this.getResourceGroupName()}'`);
+      this.log(`No deployments found for resource group '${this.configService.getResourceGroupName()}'`);
       return;
     }
     let stringDeployments = "\n\nDeployments";
@@ -89,7 +89,7 @@ export class ResourceService extends BaseService {
     this.log(`Creating resource group: ${this.resourceGroup}`);
 
     return await this.resourceClient.resourceGroups.createOrUpdate(this.resourceGroup, {
-      location: AzureNamingService.getNormalizedRegionName(this.getRegion()),
+      location: AzureNamingService.getNormalizedRegionName(this.configService.getRegion()),
     });
   }
 

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -21,4 +21,12 @@ export const constants = {
   queueName: "queueName",
   xAzureSettings: "x-azure-settings",
   entryPoint: "entryPoint",
+  variableKeys: {
+    config: "serverlessAzureConfig",
+    subscriptionId: "subscriptionId",
+    tenantId: "tenantId",
+    appId: "appId",
+    packageTimestamp: "packageTimestamp",
+    azureCredentials: "azureCredentials",
+  }
 }


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless-azure-functions/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

`ConfigService` and its usage. This removes the configuration logic from `BaseService` and keeps it all in one place. Also adds some constants for default configuration.

In a future PR, the `ConfigService` will cache its configuration so that the service is only configured one time in the initialization of the first `BaseService` subclass. It will store the data in the `serverless.variables` object and checks to see if that value is populated on future runs.

Also added some constants for default configuration values.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Removed the configuration logic from the `BaseService` and placed inside the `ConfigService`, which is initialized in the constructor of the `BaseService`

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

- Unit tests
- Run an end-to-end deployment of a service

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

_**Note: Run `npm run test:ci` to run all validation checks on proposed changes**_

- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [x] Write documentation
- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
