### PR TITLE
fix: Sync triggers on external package deployment

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -3,7 +3,7 @@ export const configConstants = {
   deploymentConfig: {
     container: "deployment-artifacts",
     rollback: true,
-    runFromBlobUrl: false,
+    external: false,
   },
   naming: {
     maxLength: {

--- a/src/models/serverless.ts
+++ b/src/models/serverless.ts
@@ -25,7 +25,7 @@ export interface FunctionAppConfig extends ResourceConfig {
 export interface DeploymentConfig {
   rollback?: boolean;
   container?: string;
-  runFromBlobUrl?: boolean;
+  external?: boolean;
 }
 
 export interface ServerlessAzureProvider {

--- a/src/services/apimService.ts
+++ b/src/services/apimService.ts
@@ -231,7 +231,7 @@ export class ApimService extends BaseService {
       return api;
     } catch (e) {
       this.log("Error creating APIM API");
-      this.log(JSON.stringify(e.body, null, 4));
+      this.log(this.stringify(e.body));
       throw e;
     }
   }
@@ -264,7 +264,7 @@ export class ApimService extends BaseService {
       });
     } catch (e) {
       this.log("Error creating APIM Backend");
-      this.log(JSON.stringify(e.body, null, 4));
+      this.log(this.stringify(e.body));
       throw e;
     }
   }
@@ -309,7 +309,7 @@ export class ApimService extends BaseService {
       return result;
     } catch (e) {
       this.log(`Error deploying API operation ${functionName}`);
-      this.log(JSON.stringify(e.body, null, 4));
+      this.log(this.stringify(e.body));
       throw e;
     }
   }
@@ -331,7 +331,7 @@ export class ApimService extends BaseService {
       });
     } catch (e) {
       this.log("Error creating APIM Property");
-      this.log(JSON.stringify(e.body, null, 4));
+      this.log(this.stringify(e.body));
       throw e;
     }
   }

--- a/src/services/baseService.ts
+++ b/src/services/baseService.ts
@@ -96,7 +96,7 @@ export abstract class BaseService {
       fs.createReadStream(filePath).pipe(
         request(requestOptions, (err, response) => {
           if (err) {
-            this.log(JSON.stringify(err, null, 4));
+            this.log(this.stringify(err));
             return reject(err);
           }
           resolve(response);
@@ -114,7 +114,11 @@ export abstract class BaseService {
   }  
 
   protected prettyPrint(object: any) {
-    this.log(JSON.stringify(object, null, 2));
+    this.log(this.stringify(object));
+  }
+
+  protected stringify(object: any): string {
+    return JSON.stringify(object, null, 2);
   }
 
   protected getOption(key: string, defaultValue?: any) {

--- a/src/services/configService.test.ts
+++ b/src/services/configService.test.ts
@@ -1,7 +1,7 @@
 import { ConfigService } from "./configService";
 import Serverless from "serverless";
 import { MockFactory } from "../test/mockFactory";
-import { ServerlessAzureConfig } from "../models/serverless";
+import { ServerlessAzureConfig, DeploymentConfig } from "../models/serverless";
 import configConstants from "../config";
 import { AzureNamingService } from "./namingService";
 
@@ -117,6 +117,38 @@ describe("Config Service", () => {
       const expectedStage = AzureNamingService.createShortStageName(service.getStage());
       const expectedResourceGroupName = `sls-${expectedRegion}-${expectedStage}-${serverless.service["service"]}-rg`;
       expect(actualResourceGroupName).toEqual(expectedResourceGroupName);
+    });
+
+    it("Gets deployment config from SLS yaml using external property", () => {
+      const deploymentConfig1: DeploymentConfig = {
+        external: true
+      }
+      serverless.service.provider["deployment"] = deploymentConfig1
+      const service1 = new ConfigService(serverless, { } as any);
+      expect(service1.getDeploymentConfig().external).toBe(true);
+
+      const deploymentConfig2: DeploymentConfig = {
+        external: false
+      }
+      serverless.service.provider["deployment"] = deploymentConfig2
+      const service2 = new ConfigService(serverless, { } as any);
+      expect(service2.getDeploymentConfig().external).toBe(false);
+    });
+
+    it("Gets deployment config from SLS yaml using runFromBlobUrl property", () => {
+      const deploymentConfig1 = {
+        runFromBlobUrl: true
+      }
+      serverless.service.provider["deployment"] = deploymentConfig1
+      const service1 = new ConfigService(serverless, { } as any);
+      expect(service1.getDeploymentConfig().external).toBe(true);
+
+      const deploymentConfig2 = {
+        runFromBlobUrl: false
+      }
+      serverless.service.provider["deployment"] = deploymentConfig2
+      const service2 = new ConfigService(serverless, { } as any);
+      expect(service2.getDeploymentConfig().external).toBe(false);
     });
   });
   

--- a/src/services/configService.ts
+++ b/src/services/configService.ts
@@ -1,7 +1,7 @@
 import Serverless from "serverless";
 import Service from "serverless/classes/Service";
 import configConstants from "../config";
-import { ServerlessAzureConfig, ServerlessAzureFunctionConfig } from "../models/serverless";
+import { ServerlessAzureConfig, ServerlessAzureFunctionConfig, DeploymentConfig } from "../models/serverless";
 import { constants } from "../shared/constants";
 import { Utils } from "../shared/utils";
 import { AzureNamingService, AzureNamingServiceOptions } from "./namingService";
@@ -68,6 +68,10 @@ export class ConfigService {
       this.config,
       (this.config.provider.deployment.rollback) ? `t${this.getTimestamp()}` : null
     )
+  }
+
+  public getDeploymentConfig(): DeploymentConfig {
+    return this.config.provider.deployment;
   }
 
   /**
@@ -167,6 +171,11 @@ export class ConfigService {
     config.provider.resourceGroup = (
       this.getOption("resourceGroup", config.provider.resourceGroup)
     ) || AzureNamingService.getResourceName(options);
+
+    // Get property from `runFromBlobUrl` for backwards compatability
+    if (deployment && deployment.external === undefined && deployment["runFromBlobUrl"] !== undefined) {
+      deployment.external = deployment["runFromBlobUrl"];
+    }
 
     config.provider.deployment = {
       ...configConstants.deploymentConfig,

--- a/src/services/packageService.ts
+++ b/src/services/packageService.ts
@@ -109,7 +109,7 @@ export class PackageService extends BaseService {
       fs.mkdirSync(functionDirPath);
     }
 
-    const functionJsonString = JSON.stringify(functionJSON, null, 2);
+    const functionJsonString = this.stringify(functionJSON);
     fs.writeFileSync(path.join(functionDirPath, "function.json"), functionJsonString);
 
     return Promise.resolve();

--- a/src/services/rollbackService.test.ts
+++ b/src/services/rollbackService.test.ts
@@ -117,7 +117,7 @@ describe("Rollback Service", () => {
   it("should deploy function app with SAS URL", async () => {
     const sls = MockFactory.createTestServerless();
     const deploymentConfig: DeploymentConfig = {
-      runFromBlobUrl: true
+      external: true
     }
     sls.service.provider["deployment"] = deploymentConfig;
     const service = createService(sls);

--- a/src/services/rollbackService.ts
+++ b/src/services/rollbackService.ts
@@ -56,7 +56,7 @@ export class RollbackService extends BaseService {
     const armDeployment = await this.convertToArmDeployment(deployment);
     // Initialize blob service for either creating SAS token or downloading artifact to uplod to function app
     await this.blobService.initialize();
-    if (this.config.provider.deployment.runFromBlobUrl) {
+    if (this.config.provider.deployment.external) {
       // Set functionRunFromPackage param to SAS URL of blob
       armDeployment.parameters.functionAppRunFromPackage = {
         type: ArmParamType.String,
@@ -71,7 +71,7 @@ export class RollbackService extends BaseService {
      * Cannot use an `else` statement just because deploying the artifact
      * depends on `deployTemplate` already being called
      */
-    if (!this.config.provider.deployment.runFromBlobUrl) {
+    if (!this.config.provider.deployment.external) {
       const artifactPath = await this.downloadArtifact(artifactName);
       await this.redeployArtifact(artifactPath);
     }

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -114,10 +114,6 @@ export class Utils {
     return metaData;
   }
 
-  public static prettyPrint(json) {
-    return JSON.stringify(json, null, 2);
-  }
-
   /**
    * Take the first `substringSize` characters from each string and return as one string
    * @param substringSize Size of substring to take from beginning of each string


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless-azure-functions/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Fix updating of function app settings (SDK call wasn't working) and syncing triggers for function apps running from external package.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

- Updated the `syncTriggers` function to use [the correct URL](https://docs.microsoft.com/en-us/azure/azure-functions/functions-deployment-technologies#trigger-syncing)
- Updated the `updateFunctionAppSetting` function to just make a rest API call instead of using the SDK. The SDK call now gives the error message: `Error: Failed to update function app settings: Error: {"Code":"BadRequest","Message":"SiteAppSettings object is not present in the request body...`. I checked with the documentation and found matching GitHub issues. Rather than the SDK call, just making a REST request according to [the docs](https://docs.microsoft.com/en-us/rest/api/appservice/webapps/updateapplicationsettings)

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

Deploy a function app with the following configuration:

```yaml
# serverless.yml
provider:
    deployment:
        external: true
```
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

_**Note: Run `npm run test:ci` to run all validation checks on proposed changes**_

- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [x] Write documentation
- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
