### PR TITLE
fix: Fix typing errors in ARM params and add interfaces

### DIFF
--- a/src/armTemplates/resources/apim.ts
+++ b/src/armTemplates/resources/apim.ts
@@ -1,7 +1,15 @@
 import { ApiManagementConfig } from "../../models/apiManagement";
-import { ArmResourceTemplate, ArmResourceTemplateGenerator, ArmParamType, ArmParameters } from "../../models/armTemplates";
+import { ArmResourceTemplate, ArmResourceTemplateGenerator, ArmParamType, ArmParameters, ArmParameter, DefaultArmParams } from "../../models/armTemplates";
 import { ServerlessAzureConfig } from "../../models/serverless";
 import { AzureNamingService, AzureNamingServiceOptions } from "../../services/namingService";
+
+interface ApimArmParams extends DefaultArmParams {
+  apiManagementName: ArmParameter;
+  apimSkuName: ArmParameter;
+  apimSkuCapacity: ArmParameter;
+  apimPublisherEmail: ArmParameter;
+  apimPublisherName: ArmParameter;
+}
 
 export class ApimResource implements ArmResourceTemplateGenerator {
   public static getResourceName(config: ServerlessAzureConfig) {
@@ -14,35 +22,36 @@ export class ApimResource implements ArmResourceTemplateGenerator {
   }
 
   public getTemplate(): ArmResourceTemplate {
+    const parameters: ApimArmParams = {
+      apiManagementName: {
+        defaultValue: "",
+        type: ArmParamType.String
+      },
+      location: {
+        defaultValue: "",
+        type: ArmParamType.String
+      },
+      apimSkuName: {
+        defaultValue: "Consumption",
+        type: ArmParamType.String
+      },
+      apimSkuCapacity: {
+        defaultValue: 0,
+        type: ArmParamType.Int
+      },
+      apimPublisherEmail: {
+        defaultValue: "contact@contoso.com",
+        type: ArmParamType.String
+      },
+      apimPublisherName: {
+        defaultValue: "Contoso",
+        type: ArmParamType.String
+      }
+    }
     return {
       "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
       "contentVersion": "1.0.0.0",
-      "parameters": {
-        "apiManagementName": {
-          "defaultValue": "",
-          "type": ArmParamType.String
-        },
-        "location": {
-          "defaultValue": "",
-          "type": ArmParamType.String
-        },
-        "apimSkuName": {
-          "defaultValue": "Consumption",
-          "type": ArmParamType.String
-        },
-        "apimCapacity": {
-          "defaultValue": 0,
-          "type": ArmParamType.Int
-        },
-        "apimPublisherEmail": {
-          "defaultValue": "contact@contoso.com",
-          "type": ArmParamType.String
-        },
-        "apimPublisherName": {
-          "defaultValue": "Contoso",
-          "type": ArmParamType.String
-        }
-      },
+      parameters,
       "variables": {},
       "resources": [
         {
@@ -72,7 +81,7 @@ export class ApimResource implements ArmResourceTemplateGenerator {
       ...config.provider.apim,
     };
 
-    return {
+    const parameters: ApimArmParams =  {
       apiManagementName: {
         value: ApimResource.getResourceName(config),
       },
@@ -89,5 +98,7 @@ export class ApimResource implements ArmResourceTemplateGenerator {
         value: apimConfig.publisherName,
       }
     };
+
+    return parameters as unknown as ArmParameters;
   }
 }

--- a/src/armTemplates/resources/appInsights.ts
+++ b/src/armTemplates/resources/appInsights.ts
@@ -1,6 +1,10 @@
-import { ArmResourceTemplate, ArmResourceTemplateGenerator, ArmParamType, ArmParameters } from "../../models/armTemplates";
+import { ArmResourceTemplate, ArmResourceTemplateGenerator, ArmParamType, ArmParameters, ArmParameter, DefaultArmParams } from "../../models/armTemplates";
 import { ServerlessAzureConfig } from "../../models/serverless";
 import { AzureNamingService, AzureNamingServiceOptions } from "../../services/namingService";
+
+interface AppInsightsParams extends DefaultArmParams {
+  appInsightsName: ArmParameter;
+}
 
 export class AppInsightsResource implements ArmResourceTemplateGenerator {
   public static getResourceName(config: ServerlessAzureConfig) {
@@ -13,19 +17,21 @@ export class AppInsightsResource implements ArmResourceTemplateGenerator {
   }
 
   public getTemplate(): ArmResourceTemplate {
+    const parameters: AppInsightsParams = {
+      appInsightsName: {
+        defaultValue: "",
+        type: ArmParamType.String
+      },
+      location: {
+        defaultValue: "",
+        type: ArmParamType.String
+      }
+    }
+    
     return {
       "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
       "contentVersion": "1.0.0.0",
-      "parameters": {
-        "appInsightsName": {
-          "defaultValue": "",
-          "type": ArmParamType.String
-        },
-        "location": {
-          "defaultValue": "",
-          "type": ArmParamType.String
-        }
-      },
+      parameters,
       "variables": {},
       "resources": [
         {
@@ -44,10 +50,12 @@ export class AppInsightsResource implements ArmResourceTemplateGenerator {
   }
 
   public getParameters(config: ServerlessAzureConfig): ArmParameters {
-    return {
+    const params: AppInsightsParams = {
       appInsightsName: {
         value: AppInsightsResource.getResourceName(config),
       }
     };
+
+    return params as unknown as ArmParameters;
   }
 }

--- a/src/armTemplates/resources/appServicePlan.ts
+++ b/src/armTemplates/resources/appServicePlan.ts
@@ -1,6 +1,12 @@
-import { ArmResourceTemplate, ArmResourceTemplateGenerator, ArmParamType, ArmParameters } from "../../models/armTemplates";
+import { ArmResourceTemplate, ArmResourceTemplateGenerator, ArmParamType, ArmParameters, DefaultArmParams, ArmParameter } from "../../models/armTemplates";
 import { ResourceConfig, ServerlessAzureConfig } from "../../models/serverless";
 import { AzureNamingService, AzureNamingServiceOptions } from "../../services/namingService";
+
+interface AppServicePlanParams extends DefaultArmParams {
+  appServicePlanName: ArmParameter;
+  appServicePlanSkuName: ArmParameter;
+  appServicePlanSkuTier: ArmParameter;
+}
 
 export class AppServicePlanResource implements ArmResourceTemplateGenerator {
   public static getResourceName(config: ServerlessAzureConfig) {
@@ -13,27 +19,29 @@ export class AppServicePlanResource implements ArmResourceTemplateGenerator {
   }
 
   public getTemplate(): ArmResourceTemplate {
+    const parameters: AppServicePlanParams = {
+      appServicePlanName: {
+        defaultValue: "",
+        type: ArmParamType.String
+      },
+      location: {
+        defaultValue: "",
+        type: ArmParamType.String
+      },
+      appServicePlanSkuName: {
+        defaultValue: "EP1",
+        type: ArmParamType.String
+      },
+      appServicePlanSkuTier: {
+        defaultValue: "ElasticPremium",
+        type: ArmParamType.String
+      }
+    };
+
     return {
       "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
       "contentVersion": "1.0.0.0",
-      "parameters": {
-        "appServicePlanName": {
-          "defaultValue": "",
-          "type": ArmParamType.String
-        },
-        "location": {
-          "defaultValue": "",
-          "type": ArmParamType.String
-        },
-        "appServicePlanSkuName": {
-          "defaultValue": "EP1",
-          "type": ArmParamType.String
-        },
-        "appServicePlanSkuTier": {
-          "defaultValue": "ElasticPremium",
-          "type": ArmParamType.String
-        }
-      },
+      parameters,
       "variables": {},
       "resources": [
         {
@@ -63,7 +71,7 @@ export class AppServicePlanResource implements ArmResourceTemplateGenerator {
       ...config.provider.storageAccount,
     };
 
-    return {
+    const params: AppServicePlanParams = {
       appServicePlanName: {
         value: AppServicePlanResource.getResourceName(config),
       },
@@ -74,5 +82,7 @@ export class AppServicePlanResource implements ArmResourceTemplateGenerator {
         value: resourceConfig.sku.tier,
       }
     }
+
+    return params as unknown as ArmParameters;
   }
 }

--- a/src/armTemplates/resources/functionApp.ts
+++ b/src/armTemplates/resources/functionApp.ts
@@ -1,10 +1,20 @@
-import { ArmResourceTemplate, ArmResourceTemplateGenerator, ArmParamType, ArmParameters } from "../../models/armTemplates";
+import { ArmResourceTemplate, ArmResourceTemplateGenerator, ArmParamType, ArmParameters, DefaultArmParams, ArmParameter } from "../../models/armTemplates";
 import { FunctionAppConfig, ServerlessAzureConfig } from "../../models/serverless";
 import { AzureNamingService, AzureNamingServiceOptions } from "../../services/namingService";
 
 //Runtime versions found at " https://<sitename>.scm.azurewebsites.net/api/diagnostics/runtime".
 import runtimeVersionsJson from "../../services/runtimeVersions.json";
 import semver from "semver";
+
+interface FunctionAppParams extends DefaultArmParams {
+  functionAppName: ArmParameter;
+  functionAppNodeVersion: ArmParameter;
+  functionAppWorkerRuntime: ArmParameter;
+  functionAppExtensionVersion: ArmParameter;
+  appInsightsName?: ArmParameter;
+  functionAppRunFromPackage?: ArmParameter;
+  storageAccountName?: ArmParameter;
+}
 
 export class FunctionAppResource implements ArmResourceTemplateGenerator {
   public static getResourceName(config: ServerlessAzureConfig) {
@@ -20,43 +30,44 @@ export class FunctionAppResource implements ArmResourceTemplateGenerator {
   }
 
   public getTemplate(): ArmResourceTemplate {
+    const parameters: FunctionAppParams = {
+      functionAppRunFromPackage: {
+        defaultValue: "1",
+        type: ArmParamType.String
+      },
+      functionAppName: {
+        defaultValue: "",
+        type: ArmParamType.String
+      },
+      functionAppNodeVersion: {
+        defaultValue: "",
+        type: ArmParamType.String
+      },
+      functionAppWorkerRuntime: {
+        defaultValue: "node",
+        type: ArmParamType.String
+      },
+      functionAppExtensionVersion: {
+        defaultValue: "~2",
+        type: ArmParamType.String
+      },
+      storageAccountName: {
+        defaultValue: "",
+        type: ArmParamType.String
+      },
+      appInsightsName: {
+        defaultValue: "",
+        type: ArmParamType.String
+      },
+      location: {
+        defaultValue: "",
+        type: ArmParamType.String
+      },
+    }
     return {
       "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
       "contentVersion": "1.0.0.0",
-      "parameters": {
-        "functionAppRunFromPackage": {
-          "defaultValue": "1",
-          "type": ArmParamType.String
-        },
-        "functionAppName": {
-          "defaultValue": "",
-          "type": ArmParamType.String
-        },
-        "functionAppNodeVersion": {
-          "defaultValue": "",
-          "type": ArmParamType.String
-        },
-        "functionAppWorkerRuntime": {
-          "defaultValue": "node",
-          "type": ArmParamType.String
-        },
-        "functionAppExtensionVersion": {
-          "defaultValue": "~2",
-          "type": ArmParamType.String
-        },
-        "storageAccountName": {
-          "defaultValue": "",
-          "type": ArmParamType.String
-        },
-        "appInsightsName": {
-          "defaultValue": "",
-          "type": ArmParamType.String
-        },
-        "location": {
-          "defaultValue": "",
-          "type": ArmParamType.String
-        },
-      },
+      parameters,
       "variables": {},
       "resources": [
         {
@@ -124,7 +135,7 @@ export class FunctionAppResource implements ArmResourceTemplateGenerator {
       nodeVersion: this.getRuntimeVersion(config.provider.runtime)
     };
 
-    return {
+    const params: FunctionAppParams = {
       functionAppName: {
         value: FunctionAppResource.getResourceName(config),
       },
@@ -138,6 +149,8 @@ export class FunctionAppResource implements ArmResourceTemplateGenerator {
         value: resourceConfig.extensionVersion,
       }
     };
+
+    return params as unknown as ArmParameters;
   }
 
   private getRuntimeVersion(runtime: string): string {

--- a/src/armTemplates/resources/hostingEnvironment.ts
+++ b/src/armTemplates/resources/hostingEnvironment.ts
@@ -1,6 +1,11 @@
-import { ArmResourceTemplate, ArmResourceTemplateGenerator, ArmParamType, ArmParameters } from "../../models/armTemplates";
+import { ArmResourceTemplate, ArmResourceTemplateGenerator, ArmParamType, ArmParameters, DefaultArmParams, ArmParameter } from "../../models/armTemplates";
 import { ServerlessAzureConfig } from "../../models/serverless";
 import { AzureNamingService, AzureNamingServiceOptions } from "../../services/namingService";
+
+export interface HostingEnvironmentParams extends DefaultArmParams {
+  hostingEnvironmentName?: ArmParameter;
+  virtualNetworkName?: ArmParameter;
+}
 
 export class HostingEnvironmentResource implements ArmResourceTemplateGenerator {
   public static getResourceName(config: ServerlessAzureConfig) {
@@ -13,23 +18,25 @@ export class HostingEnvironmentResource implements ArmResourceTemplateGenerator 
   }
 
   public getTemplate(): ArmResourceTemplate {
+    const parameters: HostingEnvironmentParams = {
+      hostingEnvironmentName: {
+        defaultValue: "",
+        type: ArmParamType.String
+      },
+      virtualNetworkName: {
+        defaultValue: "",
+        type: ArmParamType.String
+      },
+      location: {
+        defaultValue: "",
+        type: ArmParamType.String
+      }
+    }
+
     return {
       "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
       "contentVersion": "1.0.0.0",
-      "parameters": {
-        "hostingEnvironmentName": {
-          "defaultValue": "",
-          "type": ArmParamType.String
-        },
-        "virtualNetworkName": {
-          "defaultValue": "",
-          "type": ArmParamType.String
-        },
-        "location": {
-          "defaultValue": "",
-          "type": ArmParamType.String
-        }
-      },
+      parameters,
       "variables": {},
       "resources": [
         {
@@ -66,11 +73,13 @@ export class HostingEnvironmentResource implements ArmResourceTemplateGenerator 
   }
 
   public getParameters(config: ServerlessAzureConfig): ArmParameters {
-    return {
+    const params: HostingEnvironmentParams = {
       hostingEnvironmentName: {
         value: HostingEnvironmentResource.getResourceName(config)
       }
     }
+
+    return params as unknown as ArmParameters;
   }
 }
 

--- a/src/armTemplates/resources/storageAccount.ts
+++ b/src/armTemplates/resources/storageAccount.ts
@@ -1,7 +1,13 @@
 import configConstants from "../../config";
-import { ArmParameters, ArmParamType, ArmResourceTemplate, ArmResourceTemplateGenerator } from "../../models/armTemplates";
+import { ArmParameters, ArmParamType, ArmResourceTemplate, ArmResourceTemplateGenerator, DefaultArmParams, ArmParameter } from "../../models/armTemplates";
 import { ResourceConfig, ServerlessAzureConfig } from "../../models/serverless";
 import { AzureNamingService, AzureNamingServiceOptions } from "../../services/namingService";
+
+interface StorageAccountParams extends DefaultArmParams {
+  storageAccountName: ArmParameter;
+  storageAccountSkuName: ArmParameter;
+  storageAccountSkuTier: ArmParameter;
+}
 
 export class StorageAccountResource implements ArmResourceTemplateGenerator {
   public static getResourceName(config: ServerlessAzureConfig) {
@@ -17,27 +23,28 @@ export class StorageAccountResource implements ArmResourceTemplateGenerator {
   }
 
   public getTemplate(): ArmResourceTemplate {
+    const parameters: StorageAccountParams = {
+      storageAccountName: {
+        defaultValue: "",
+        type: ArmParamType.String
+      },
+      location: {
+        defaultValue: "",
+        type: ArmParamType.String
+      },
+      storageAccountSkuName: {
+        defaultValue: "Standard_LRS",
+        type: ArmParamType.String
+      },
+      storageAccountSkuTier: {
+        defaultValue: "Standard",
+        type: ArmParamType.String
+      }
+    }
     return {
       "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
       "contentVersion": "1.0.0.0",
-      "parameters": {
-        "storageAccountName": {
-          "defaultValue": "",
-          "type": ArmParamType.String
-        },
-        "location": {
-          "defaultValue": "",
-          "type": ArmParamType.String
-        },
-        "storageAccountSkuName": {
-          "defaultValue": "Standard_LRS",
-          "type": ArmParamType.String
-        },
-        "storageAccoutSkuTier": {
-          "defaultValue": "Standard",
-          "type": ArmParamType.String
-        }
-      },
+      parameters,
       variables: {},
       resources: [
         {
@@ -51,7 +58,7 @@ export class StorageAccountResource implements ArmResourceTemplateGenerator {
           },
           sku: {
             name: "[parameters('storageAccountSkuName')]",
-            tier: "[parameters('storageAccoutSkuTier')]"
+            tier: "[parameters('storageAccountSkuTier')]"
           }
         }
       ]
@@ -64,16 +71,18 @@ export class StorageAccountResource implements ArmResourceTemplateGenerator {
       ...config.provider.storageAccount
     };
 
-    return {
+    const params: StorageAccountParams = {
       storageAccountName: {
         value: StorageAccountResource.getResourceName(config),
       },
       storageAccountSkuName: {
         value: resourceConfig.sku.name,
       },
-      storageAccoutSkuTier: {
+      storageAccountSkuTier: {
         value: resourceConfig.sku.tier,
       }
     };
+
+    return params as unknown as ArmParameters;
   }
 }

--- a/src/armTemplates/resources/virtualNetwork.ts
+++ b/src/armTemplates/resources/virtualNetwork.ts
@@ -1,6 +1,7 @@
 import { ArmResourceTemplate, ArmResourceTemplateGenerator, ArmParamType, ArmParameters } from "../../models/armTemplates";
 import { ServerlessAzureConfig } from "../../models/serverless";
 import { AzureNamingService, AzureNamingServiceOptions } from "../../services/namingService";
+import { HostingEnvironmentParams } from "./hostingEnvironment";
 
 export class VirtualNetworkResource implements ArmResourceTemplateGenerator {
   public static getResourceName(config: ServerlessAzureConfig) {
@@ -13,23 +14,24 @@ export class VirtualNetworkResource implements ArmResourceTemplateGenerator {
   }
 
   public getTemplate(): ArmResourceTemplate {
+    const parameters: HostingEnvironmentParams = {
+      hostingEnvironmentName: {
+        defaultValue: "",
+        type: ArmParamType.String
+      },
+      virtualNetworkName: {
+        defaultValue: "",
+        type: ArmParamType.String
+      },
+      location: {
+        defaultValue: "",
+        type: ArmParamType.String
+      }
+    }
     return {
       "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
       "contentVersion": "1.0.0.0",
-      "parameters": {
-        "hostingEnvironmentName": {
-          "defaultValue": "",
-          "type": ArmParamType.String
-        },
-        "virtualNetworkName": {
-          "defaultValue": "",
-          "type": ArmParamType.String
-        },
-        "location": {
-          "defaultValue": "",
-          "type": ArmParamType.String
-        }
-      },
+      parameters,
       "variables": {},
       "resources": [
         {
@@ -84,11 +86,13 @@ export class VirtualNetworkResource implements ArmResourceTemplateGenerator {
   }
 
   public getParameters(config: ServerlessAzureConfig): ArmParameters {
-    return {
+    const params: HostingEnvironmentParams = {
       virtualNetworkName: {
         value: VirtualNetworkResource.getResourceName(config),
       }
     }
+
+    return params as unknown as ArmParameters;
   }
 }
 

--- a/src/models/armTemplates.ts
+++ b/src/models/armTemplates.ts
@@ -45,11 +45,17 @@ export interface ArmResourceTemplate {
 }
 
 export interface ArmParameters {
-  [key: string]: {
-    type?: ArmParamType;
-    value?: string | number;
-    defaultValue?: string | number;
-  };
+  [key: string]: ArmParameter;
+}
+
+export interface ArmParameter {
+  type?: ArmParamType;
+  value?: string | number;
+  defaultValue?: string | number;
+}
+
+export interface DefaultArmParams {
+  location?: ArmParameter;
 }
 
 /**


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless-azure-functions/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Fixed mismatched ARM parameter names and spelling errors. Added interfaces for all resource ARM parameters to prevent future occurrence.

- [x] Fixed `apimCapacity` to be `apimSkuCapacity`
- [x] Fixed `storageAccoutTier` to be `storageAccountTier`

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

- Fixed spelling errors
- Added internal interfaces that act as a "spell check" for the developer when returning the parameters from the `getParameters` function

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

No real functionality changes. Deploy should still work as normal

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

_**Note: Run `npm run test:ci` to run all validation checks on proposed changes**_

- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [x] Write documentation
- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES 
**_Is it a breaking change?:_** NO
