### PR TITLE
ci: fix failing Node 8 builds on windows agent

### DIFF
--- a/pipelines/ci.yml
+++ b/pipelines/ci.yml
@@ -12,8 +12,8 @@ variables:
 jobs:
   - template: templates/unit-tests.yml # path relative to this file
     parameters:
-      nodeVersion: 8.16.1
+      nodeVersion: "8.16.1"
 
   - template: templates/unit-tests.yml
     parameters:
-      nodeVersion: 10
+      nodeVersion: 10.x

--- a/pipelines/ci.yml
+++ b/pipelines/ci.yml
@@ -13,9 +13,9 @@ jobs:
   - template: templates/unit-tests.yml # path relative to this file
     parameters:
       nodeVersion: "8.16.1"
-      name: "8"
+      name: "Node_8"
 
   - template: templates/unit-tests.yml
     parameters:
       nodeVersion: 10.x
-      name: "10"
+      name: "Node_10"

--- a/pipelines/ci.yml
+++ b/pipelines/ci.yml
@@ -13,7 +13,9 @@ jobs:
   - template: templates/unit-tests.yml # path relative to this file
     parameters:
       nodeVersion: "8.16.1"
+      name: "8"
 
   - template: templates/unit-tests.yml
     parameters:
       nodeVersion: 10.x
+      name: "10"

--- a/pipelines/ci.yml
+++ b/pipelines/ci.yml
@@ -7,13 +7,13 @@ pr:
   - dev
 
 variables:
-- group: code-coverage-credentials  # variable group
+  - group: code-coverage-credentials # variable group
 
 jobs:
-- template: templates/unit-tests.yml  # path relative to this file
-  parameters:
-    nodeVersion: 8
+  - template: templates/unit-tests.yml # path relative to this file
+    parameters:
+      nodeVersion: 8.16.1
 
-- template: templates/unit-tests.yml
-  parameters:
-    nodeVersion: 10
+  - template: templates/unit-tests.yml
+    parameters:
+      nodeVersion: 10

--- a/pipelines/templates/unit-tests.yml
+++ b/pipelines/templates/unit-tests.yml
@@ -1,44 +1,44 @@
 jobs:
-- job: "${{ parameters.os }}_${{ parameters.nodeVersion }}"
-  strategy:
-    matrix:
-      linux:
-        imageName: 'ubuntu-16.04'
-      mac:
-        imageName: 'macos-10.13'
-      windows:
-        imageName: 'vs2017-win2016'
-  displayName: "NodeJs_${{ parameters.nodeVersion }}"
-  pool:
-    vmImage: $(imageName)
+  - job: "${{ parameters.nodeVersion }}"
+    strategy:
+      matrix:
+        linux:
+          imageName: "ubuntu-16.04"
+        mac:
+          imageName: "macos-10.13"
+        windows:
+          imageName: "vs2017-win2016"
+    displayName: "$(imageName)_${{ parameters.nodeVersion }}"
+    pool:
+      vmImage: $(imageName)
 
-  steps:
-  - task: NodeTool@0
-    displayName: 'Use Node ${{ parameters.nodeVersion }}'
-    inputs:
-      versionSpec: ${{ parameters.nodeVersion }}.x
+    steps:
+      - task: NodeTool@0
+        displayName: "Use Node ${{ parameters.nodeVersion }}"
+        inputs:
+          versionSpec: ${{ parameters.nodeVersion }}
 
-  - bash: |
-      set -e
-      
-      npm ci
-      npm run compile
-      npm run test:coverage  # linting is run as part of pretest
-    displayName: 'Run tests'
+      - bash: |
+          set -e
 
-  - ${{ if eq(parameters.nodeVersion, '8') }}:
-    - bash: |
-        set -e
+          npm ci
+          npm run compile
+          npm run test:coverage  # linting is run as part of pretest
+        displayName: "Run tests"
 
-        token=$(CODECOV_TOKEN)
-        if [[ -z "${token}" ]]; then
-          echo "Need to set CODECOV_TOKEN"
-          exit 1
-        fi
+      - ${{ if eq(parameters.nodeVersion, '8.16.1') }}:
+          - bash: |
+              set -e
 
-        # https://docs.codecov.io/docs/about-the-codecov-bash-uploader
-        bash <(curl -s https://codecov.io/bash) -t ${token}
-      displayName: 'Upload code coverage report'
-      env:
-        CODECOV_TOKEN: $(CODECOV_TOKEN)
-      condition: eq(variables['imageName'], 'ubuntu-16.04')
+              token=$(CODECOV_TOKEN)
+              if [[ -z "${token}" ]]; then
+                echo "Need to set CODECOV_TOKEN"
+                exit 1
+              fi
+
+              # https://docs.codecov.io/docs/about-the-codecov-bash-uploader
+              bash <(curl -s https://codecov.io/bash) -t ${token}
+            displayName: "Upload code coverage report"
+            env:
+              CODECOV_TOKEN: $(CODECOV_TOKEN)
+            condition: eq(variables['imageName'], 'ubuntu-16.04')

--- a/pipelines/templates/unit-tests.yml
+++ b/pipelines/templates/unit-tests.yml
@@ -1,5 +1,5 @@
 jobs:
-  - job: "${{ parameters.name }}"
+  - job: "${{parameters.os}}_${{ parameters.name }}"
     strategy:
       matrix:
         linux:

--- a/pipelines/templates/unit-tests.yml
+++ b/pipelines/templates/unit-tests.yml
@@ -1,5 +1,5 @@
 jobs:
-  - job: "${{parameters.os}}_${{ parameters.name }}"
+  - job: "${{ parameters.name }}"
     strategy:
       matrix:
         linux:
@@ -8,7 +8,7 @@ jobs:
           imageName: "macos-10.13"
         windows:
           imageName: "vs2017-win2016"
-    displayName: "$(imageName)_${{ parameters.nodeVersion }}"
+    displayName: "${{ parameters.name }}"
     pool:
       vmImage: $(imageName)
 

--- a/pipelines/templates/unit-tests.yml
+++ b/pipelines/templates/unit-tests.yml
@@ -1,5 +1,5 @@
 jobs:
-  - job: "${{ parameters.nodeVersion }}"
+  - job: "${{ parameters.name }}"
     strategy:
       matrix:
         linux:


### PR DESCRIPTION
Hosted agent roll out a fix that broke our builds:

1. Previously, npm wasn’t getting packaged with the version of node in the tool cache,
ie. npm 5.6.0 should be used alongside Node 8.10.0.

1. The fix is to pin to a later version of Node 8 (e.g. 8.16.1) which comes with npm 6+
- https://nodejs.org/en/download/releases/.
  * This will probably slow the build down a little bit since the agent will have to download
  the version (instead of it being pre-installed), but we'll get the right version of npm for free.

<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless-azure-functions/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Closes #344 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place (e.g. AWS CLI commands)
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

_**Note: Run `npm run test:ci` to run all validation checks on proposed changes**_

- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [x] Write documentation
- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Make sure code coverage hasn't dropped
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES  
**_Is it a breaking change?:_** NO
