### PR TITLE
feat: Resource group tagging

### DIFF
--- a/docs/DEPLOY.md
+++ b/docs/DEPLOY.md
@@ -14,6 +14,20 @@ By default, all functions are deploy to a stage (`dev`) and a region. The autoge
 - Create/Update app service plan, app service
 - Zipdeploy code
 
+### Tagging resource group
+
+To apply tags to your resource group, you can specify them in your provider config as such:
+
+```yaml
+...
+provider:
+  tags:
+    TAG_1: tagValue1
+    TAG_2: tagValue2
+```
+
+Existing tags with the same names will be updated. Existing tags (with different names) will **not** be removed.
+
 ### No resource group specified
 
 `sls deploy -s dev -r westus2`
@@ -41,7 +55,7 @@ then user try to deploy
 `sls deploy -s prod -r westus`
 
 1. Do we use the environment variables / creds associated with `dev` or `prod`?
-1. Someone new to the codecase see both the `serverless.yaml` and the command in a CD script, how can they tell which resourceGroup goes where.
+2. Someone new to the codecase see both the `serverless.yaml` and the command in a CD script, how can they tell which resourceGroup goes where.
 
 #### Specifying resourceGroup in command line
 

--- a/src/models/serverless.ts
+++ b/src/models/serverless.ts
@@ -40,6 +40,9 @@ export interface ServerlessAzureProvider {
   environment?: {
     [key: string]: any;
   };
+  tags?: {
+    [tagName: string]: string;
+  };
   deployment?: DeploymentConfig;
   deploymentName?: string;
   resourceGroup?: string;

--- a/src/services/resourceService.ts
+++ b/src/services/resourceService.ts
@@ -4,7 +4,7 @@ import { BaseService } from "./baseService";
 import { Utils } from "../shared/utils";
 import { AzureNamingService } from "./namingService";
 import { ArmDeployment, ArmTemplateProvisioningState } from "../models/armTemplates";
-import { DeploymentExtended } from "@azure/arm-resources/esm/models";
+import { DeploymentExtended, ResourceGroupsGetResponse } from "@azure/arm-resources/esm/models";
 
 export class ResourceService extends BaseService {
   private resourceClient: ResourceManagementClient;
@@ -87,10 +87,24 @@ export class ResourceService extends BaseService {
 
   public async deployResourceGroup() {
     this.log(`Creating resource group: ${this.resourceGroup}`);
+    
+    const resourceGroup = await this.getResourceGroup();
 
     return await this.resourceClient.resourceGroups.createOrUpdate(this.resourceGroup, {
       location: AzureNamingService.getNormalizedRegionName(this.configService.getRegion()),
+      tags: {
+        ...((resourceGroup) ? resourceGroup.tags : undefined),
+        ...this.config.provider.tags
+      }
     });
+  }
+
+  public async getResourceGroup(): Promise<ResourceGroupsGetResponse> {
+    try {
+      return await this.resourceClient.resourceGroups.get(this.resourceGroup);
+    } catch (e) {
+      return undefined;
+    }
   }
 
   public async deleteDeployment() {


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless-azure-functions/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Tagging for the Azure resource group as defined within the `provider`. Example

```yaml
...
provider:
    tags:
        TAG_1: tag1Value
        TAG_2: tag2Value
```

## How did you implement it:

- Check for existing resource group
- Merge tags from existing with tags from provider config
- Add tags to `createOrUpdate` call of resource group

## How can we verify it:

- Deploy a service with `tags` defined in provider config

OR

- Manually define tag for resource group in Azure portal
- Deploy service
- Tag will not be lost

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

_**Note: Run `npm run test:ci` to run all validation checks on proposed changes**_

- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [x] Write documentation
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
