### PR TITLE
feat: Linux & Python Runtime Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ $ cd <appName>
 $ npm install
 ```
 
+The `serverless.yml` file contains the configuration for your service. For more details on its configuration, see [the docs](docs/CONFIG.md).
+
 ### Running Function App Locally (`offline` plugin)
 
 In order to run a Azure Function App locally, the `azure-functions-core-tools` package needs to be installed from NPM. Since it is only used for local development, we did not include it in the `devDependencies` of `package.json`. To install globally, run:

--- a/README.md
+++ b/README.md
@@ -59,8 +59,16 @@ $ sls offline build
 To clean up files generated from the build, run:
 
 ```bash
-sls offline cleanup
+$ sls offline cleanup
 ```
+
+To pass additional arguments to the spawned `func host start` process, add them as the option `spawnargs` (shortcut `a`). Example:
+
+```bash
+$ sls offline -a "--cors *"
+```
+
+This works for `sls offline` or `sls offline start`
 
 ### Deploy Your Function App
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -1,0 +1,39 @@
+# Serverless Configuration
+
+This document serves as a basic outline for configuring your Azure Function App through `serverless.yml`
+
+## Function Runtime
+
+### Operating System:
+
+#### Supported Operating Systems:
+- `windows`
+- `linux`
+
+#### How to specify operating system:
+```yaml
+...
+provider:
+  os: linux
+...
+```
+Default is windows
+
+### Language
+
+#### Supported Languages:
+- node
+- python
+
+#### How to specify language:
+
+```yaml
+...
+provider:
+  runtime: nodejs10.x
+...
+```
+
+All supported runtimes can be found [in this file](https://github.com/serverless/serverless-azure-functions/blob/master/src/services/runtimeVersions.json). The notation `.x` signifies to use the highest version within that major or minor release.
+
+**Note**: Azure functions only supports Python 3.6. Specify that by using `python3.6`

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "typings": "./lib/index.d.ts",
   "author": "Azure Functions",
   "scripts": {
-    "start": "jest --watch",
+    "start": "npm run test -- --watch",
     "lint": "eslint src/**/*.ts",
     "lint:fix": "eslint src/**/*.ts --fix",
     "pretest": "npm run lint",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "typings": "./lib/index.d.ts",
   "author": "Azure Functions",
   "scripts": {
-    "start": "npm run test -- --watch",
+    "start": "jest --watch",
     "lint": "eslint src/**/*.ts",
     "lint:fix": "eslint src/**/*.ts --fix",
     "pretest": "npm run lint",

--- a/src/armTemplates/resources/appServicePlan.ts
+++ b/src/armTemplates/resources/appServicePlan.ts
@@ -104,6 +104,11 @@ export class AppServicePlanResource implements ArmResourceTemplateGenerator {
       appServicePlanName: {
         value: AppServicePlanResource.getResourceName(config),
       },
+      /**
+       * `kind` only required for Linux Function Apps
+       * `undefined` values get removed from parameters by armService
+       * before deployment
+       */
       kind: {
         value: (os === FunctionAppOS.LINUX) ? "Linux" : undefined,
       },

--- a/src/armTemplates/resources/appServicePlan.ts
+++ b/src/armTemplates/resources/appServicePlan.ts
@@ -1,9 +1,10 @@
 import { ArmResourceTemplate, ArmResourceTemplateGenerator, ArmParamType, ArmParameters, DefaultArmParams, ArmParameter } from "../../models/armTemplates";
-import { ResourceConfig, ServerlessAzureConfig } from "../../models/serverless";
+import { ResourceConfig, ServerlessAzureConfig, FunctionAppOS } from "../../models/serverless";
 import { AzureNamingService, AzureNamingServiceOptions } from "../../services/namingService";
 
 interface AppServicePlanParams extends DefaultArmParams {
   appServicePlanName: ArmParameter;
+  kind: ArmParameter;
   appServicePlanSkuName: ArmParameter;
   appServicePlanSkuTier: ArmParameter;
   appServicePlanWorkerSizeId: ArmParameter;
@@ -27,6 +28,10 @@ export class AppServicePlanResource implements ArmResourceTemplateGenerator {
       appServicePlanName: {
         defaultValue: "",
         type: ArmParamType.String
+      },
+      kind: {
+        defaultValue: "",
+        type: ArmParamType.String,
       },
       location: {
         defaultValue: "",
@@ -69,6 +74,7 @@ export class AppServicePlanResource implements ArmResourceTemplateGenerator {
           "name": "[parameters('appServicePlanName')]",
           "type": "Microsoft.Web/serverfarms",
           "location": "[parameters('location')]",
+          "kind": "[parameters('kind')]",
           "properties": {
             "name": "[parameters('appServicePlanName')]",
             "workerSizeId": "[parameters('appServicePlanWorkerSizeId')]",
@@ -92,9 +98,14 @@ export class AppServicePlanResource implements ArmResourceTemplateGenerator {
       ...config.provider.appServicePlan,
     };
 
+    const { os } = config.provider;
+
     const params: AppServicePlanParams = {
       appServicePlanName: {
         value: AppServicePlanResource.getResourceName(config),
+      },
+      kind: {
+        value: (os === FunctionAppOS.LINUX) ? "Linux" : undefined,
       },
       appServicePlanSkuName: {
         value: resourceConfig.sku.name,

--- a/src/armTemplates/resources/functionApp.test.ts
+++ b/src/armTemplates/resources/functionApp.test.ts
@@ -1,27 +1,31 @@
 import { FunctionAppResource } from "./functionApp";
-import { ServerlessAzureConfig } from "../../models/serverless";
+import { ServerlessAzureConfig, FunctionAppOS, SupportedRuntimeLanguage } from "../../models/serverless";
 
 describe("Function App Resource", () => {
+
   const resourceGroupName = "myResourceGroup";
   const prefix = "prefix";
   const region = "westus";
   const stage = "prod";
 
-  it("generates the correct resource name", () => {
-    const config: ServerlessAzureConfig = {
-      provider: {
-        name: "azure",
-        prefix,
-        region,
-        stage,
-        resourceGroup: resourceGroupName,
-        runtime: "nodejs10.x"
-      },
-      service: ""
-    } as any;
+  const defaultConfig: ServerlessAzureConfig = {
+    provider: {
+      name: "azure",
+      prefix,
+      region,
+      stage,
+      resourceGroup: resourceGroupName,
+      functionRuntime: {
+        language: SupportedRuntimeLanguage.NODE,
+        version: "10.6.0"
+      }
+    },
+    service: ""
+  } as any;
 
-    expect(FunctionAppResource.getResourceName(config)).toEqual(
-      `${config.provider.prefix}-wus-${config.provider.stage}`
+  it("generates the correct resource name", () => {
+    expect(FunctionAppResource.getResourceName(defaultConfig)).toEqual(
+      `${defaultConfig.provider.prefix}-wus-${defaultConfig.provider.stage}`
     );
   });
 
@@ -29,23 +33,94 @@ describe("Function App Resource", () => {
     const serviceName = "myapp";
 
     const config: ServerlessAzureConfig = {
+      ...defaultConfig,
       provider: {
-        apim: {
-          name: ""
-        },
-        name: "azure",
-        prefix,
-        region,
-        stage,
-        resourceGroup: resourceGroupName,
-        runtime: "nodejs10.x",
+        ...defaultConfig.provider,
         functionApp: {
-          name: serviceName,
-        },
-      },
-      service: serviceName
-    } as any;
+          name: serviceName
+        }
+      }
+    };
 
     expect(FunctionAppResource.getResourceName(config)).toEqual(serviceName);
+  });
+
+  describe("Linux parameters", () => {
+    it("gets correct parameters - node 10", () => {
+      const config: ServerlessAzureConfig = {
+        ...defaultConfig,
+        provider: {
+          ...defaultConfig.provider,
+          os: FunctionAppOS.LINUX
+        }
+      }
+  
+      const resource = new FunctionAppResource();
+      
+      const params = resource.getParameters(config);
+      const { 
+        functionAppKind,
+        functionAppReserved,
+        linuxFxVersion
+      } = params;
+  
+      expect(functionAppKind.value).toEqual("functionapp,linux");
+      expect(functionAppReserved.value).toBe(true)
+      expect(linuxFxVersion.value).toEqual("DOCKER|microsoft/azure-functions/node:2.0");
+    });
+  
+    it("gets correct linux parameters - node 8", () => {
+      const config: ServerlessAzureConfig = {
+        ...defaultConfig,
+        provider: {
+          ...defaultConfig.provider,
+          os: FunctionAppOS.LINUX,
+          functionRuntime: {
+            language: SupportedRuntimeLanguage.NODE,
+            version: "8.11.1",
+          }
+        }
+      }
+  
+      const resource = new FunctionAppResource();
+      
+      const params = resource.getParameters(config);
+      const { 
+        functionAppKind,
+        functionAppReserved,
+        linuxFxVersion
+      } = params;
+  
+      expect(functionAppKind.value).toEqual("functionapp,linux");
+      expect(functionAppReserved.value).toBe(true)
+      expect(linuxFxVersion.value).toEqual("DOCKER|microsoft/azure-functions-node8:2.0");
+    });
+
+    it("gets correct linux parameters - python 3.6", () => {
+      const config: ServerlessAzureConfig = {
+        ...defaultConfig,
+        provider: {
+          ...defaultConfig.provider,
+          os: FunctionAppOS.LINUX,
+          functionRuntime: {
+            language: SupportedRuntimeLanguage.PYTHON,
+            version: "3.6",
+          }
+        }
+      }
+  
+      const resource = new FunctionAppResource();
+      
+      const params = resource.getParameters(config);
+      const { 
+        functionAppKind,
+        functionAppReserved,
+        linuxFxVersion
+      } = params;
+  
+      expect(functionAppKind.value).toEqual("functionapp,linux");
+      expect(functionAppReserved.value).toBe(true)
+      expect(linuxFxVersion.value).toEqual("DOCKER|microsoft/azure-functions/python:2.0");
+    });
   });
 });

--- a/src/armTemplates/resources/functionApp.ts
+++ b/src/armTemplates/resources/functionApp.ts
@@ -4,15 +4,49 @@ import { AzureNamingService, AzureNamingServiceOptions } from "../../services/na
 import configConstants from "../../config";
 
 interface FunctionAppParams extends DefaultArmParams {
+  /**
+   * Name of function app
+   */
   functionAppName: ArmParameter;
+  /**
+   * Node version of function app
+   */
   functionAppNodeVersion: ArmParameter;
+  /**
+   * Kind of function app
+   * `functionapp` for Windows function app
+   * `functionapp,linux` for Linux function app
+   */
   functionAppKind: ArmParameter;
+  /**
+   * Needs to be `true` for Linux function apps
+   */
   functionAppReserved: ArmParameter;
+  /**
+   * Docker image for Linux function app
+   */
   linuxFxVersion: ArmParameter;
+  /**
+   * Runtime language. Supported values: `node` and `python`
+   */
   functionAppWorkerRuntime: ArmParameter;
+  /**
+   * Function app version. Default: `~2`
+   */
   functionAppExtensionVersion: ArmParameter;
+  /**
+   * Name of App Insights resource
+   */
   appInsightsName?: ArmParameter;
+  /**
+   * Indicates where function app code package is located
+   * `1` (default value) if uploaded directly to function app
+   * Could also be URL if running from external package
+   */
   functionAppRunFromPackage?: ArmParameter;
+  /**
+   * Name of storage account used by function app
+   */
   storageAccountName?: ArmParameter;
 }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -59,13 +59,10 @@ export const configConstants = {
   },
   bindingsJsonUrl: "https://raw.githubusercontent.com/Azure/azure-functions-templates/master/Functions.Templates/Bindings/bindings.json",
   defaultFuncIgnore: [
-    "package.json",
-    "package-lock.json",
     "README.md",
     ".gitignore",
     ".git/**",
     ".vscode/**",
-    "node_modules/**",
     "local.settings.json",
     ".serverless/**",
   ],

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,3 +1,5 @@
+import { FunctionAppOS } from "./models/serverless";
+
 export const configConstants = {
   bearer: "Bearer ",
   deploymentConfig: {
@@ -19,8 +21,12 @@ export const configConstants = {
   functionAppDomain: ".azurewebsites.net",
   functionsAdminApiPath: "/admin/functions/",
   functionsApiPath: "/api/functions",
-  funcCoreTools: "func",
-  funcCoreToolsArgs: ["host", "start"],
+  func: {
+    command: "func",
+    start: ["host", "start"],
+    pack: ["pack"],
+    publish: ["azure", "functionapp", "publish"]
+  },
   funcConsoleColor: "blue",
   runFromPackageSetting: "WEBSITE_RUN_FROM_PACKAGE",
   jsonContentType: "application/json",
@@ -40,8 +46,29 @@ export const configConstants = {
     stage: "dev",
     prefix: "sls",
     localPort: 7071,
+    os: FunctionAppOS.WINDOWS,
   },
-  bindingsJsonUrl: "https://raw.githubusercontent.com/Azure/azure-functions-templates/master/Functions.Templates/Bindings/bindings.json"
+  dockerImages: {
+    node: {
+      "8": "DOCKER|microsoft/azure-functions-node8:2.0",
+      "10": "DOCKER|microsoft/azure-functions/node:2.0"
+    },
+    python: {
+      "3.6": "DOCKER|microsoft/azure-functions/python:2.0"
+    }
+  },
+  bindingsJsonUrl: "https://raw.githubusercontent.com/Azure/azure-functions-templates/master/Functions.Templates/Bindings/bindings.json",
+  defaultFuncIgnore: [
+    "package.json",
+    "package-lock.json",
+    "README.md",
+    ".gitignore",
+    ".git/**",
+    ".vscode/**",
+    "node_modules/**",
+    "local.settings.json",
+    ".serverless/**",
+  ],
 };
 
 export default configConstants;

--- a/src/models/armTemplates.ts
+++ b/src/models/armTemplates.ts
@@ -29,6 +29,7 @@ export enum ArmParamType {
   String = "String",
   Int = "Int",
   SystemAssigned = "SystemAssigned",
+  Bool = "Bool",
 }
 
 /**
@@ -50,8 +51,8 @@ export interface ArmParameters {
 
 export interface ArmParameter {
   type?: ArmParamType;
-  value?: string | number;
-  defaultValue?: string | number;
+  value?: string | number | boolean;
+  defaultValue?: string | number | boolean;
 }
 
 export interface DefaultArmParams extends ArmParameters {

--- a/src/models/serverless.ts
+++ b/src/models/serverless.ts
@@ -55,7 +55,9 @@ export interface ServerlessAzureProvider {
   virtualNetwork?: ResourceConfig;
   armTemplate?: ArmTemplateConfig;
   keyVaultConfig?: AzureKeyVaultConfig;
+  /** Runtime setting within `serverless.yml` */
   runtime: string;
+  /** Only to be used internally. Derived from `runtime` property */
   functionRuntime?: FunctionRuntime;
   os?: FunctionAppOS;
 }

--- a/src/models/serverless.ts
+++ b/src/models/serverless.ts
@@ -57,6 +57,7 @@ export interface ServerlessAzureProvider {
   keyVaultConfig?: AzureKeyVaultConfig;
   runtime: string;
   functionRuntime?: FunctionRuntime;
+  os?: FunctionAppOS;
 }
 
 export enum FunctionAppOS {
@@ -157,6 +158,8 @@ export interface ServerlessAzureConfig {
     individually: boolean;
     artifactDirectoryName: string;
     artifact: string;
+    exclude: string[];
+    include: string[];
   };
 }
 

--- a/src/plugins/azureBasePlugin.ts
+++ b/src/plugins/azureBasePlugin.ts
@@ -1,6 +1,6 @@
 import Serverless from "serverless";
 import { ServerlessAzureConfig, ServerlessCliCommand,
-  ServerlessCommandMap, ServerlessHookMap, ServerlessObject } from "../models/serverless";
+  ServerlessCommandMap, ServerlessHookMap, ServerlessObject, FunctionAppOS } from "../models/serverless";
 import { Guard } from "../shared/guard";
 import { Utils } from "../shared/utils";
 
@@ -10,6 +10,10 @@ export abstract class AzureBasePlugin<TOptions=Serverless.Options> {
   protected config: ServerlessAzureConfig;
   protected commands: ServerlessCommandMap;
   protected processedCommands: ServerlessCliCommand[];
+  /**
+   * Specifies if targeted runtime is linux
+   */
+  protected isLinuxTarget: boolean;
 
   public constructor(
     protected serverless: Serverless,
@@ -18,6 +22,9 @@ export abstract class AzureBasePlugin<TOptions=Serverless.Options> {
     Guard.null(serverless);
     this.config = serverless.service as any;
     this.processedCommands = (serverless as any as ServerlessObject).processedInput.commands;
+    const { provider } = serverless.service
+    this.isLinuxTarget = provider["os"] === FunctionAppOS.LINUX ||
+      provider.runtime.includes("python");
   }
 
   protected log(message: string) {

--- a/src/plugins/azureBasePlugin.ts
+++ b/src/plugins/azureBasePlugin.ts
@@ -1,6 +1,6 @@
 import Serverless from "serverless";
 import { ServerlessAzureConfig, ServerlessCliCommand,
-  ServerlessCommandMap, ServerlessHookMap, ServerlessObject, FunctionAppOS } from "../models/serverless";
+  ServerlessCommandMap, ServerlessHookMap, ServerlessObject } from "../models/serverless";
 import { Guard } from "../shared/guard";
 import { Utils } from "../shared/utils";
 

--- a/src/plugins/azureBasePlugin.ts
+++ b/src/plugins/azureBasePlugin.ts
@@ -10,10 +10,6 @@ export abstract class AzureBasePlugin<TOptions=Serverless.Options> {
   protected config: ServerlessAzureConfig;
   protected commands: ServerlessCommandMap;
   protected processedCommands: ServerlessCliCommand[];
-  /**
-   * Specifies if targeted runtime is linux
-   */
-  protected isLinuxTarget: boolean;
 
   public constructor(
     protected serverless: Serverless,
@@ -22,9 +18,6 @@ export abstract class AzureBasePlugin<TOptions=Serverless.Options> {
     Guard.null(serverless);
     this.config = serverless.service as any;
     this.processedCommands = (serverless as any as ServerlessObject).processedInput.commands;
-    const { provider } = serverless.service
-    this.isLinuxTarget = provider["os"] === FunctionAppOS.LINUX ||
-      provider.runtime.includes("python");
   }
 
   protected log(message: string) {

--- a/src/plugins/login/utils/simpleFileTokenCache.test.ts
+++ b/src/plugins/login/utils/simpleFileTokenCache.test.ts
@@ -3,10 +3,7 @@ import os from "os";
 import mockFs from "mock-fs";
 import { MockFactory } from "../../../test/mockFactory";
 import { SimpleFileTokenCache } from "./simpleFileTokenCache";
-let fs;
-jest.isolateModules(() => {
-  fs = require("fs");
-});
+import fs from "fs";
 
 describe("Simple File Token Cache", () => {
   const tokenFilePath = "slsTokenCache.json";

--- a/src/plugins/login/utils/simpleFileTokenCache.test.ts
+++ b/src/plugins/login/utils/simpleFileTokenCache.test.ts
@@ -1,9 +1,12 @@
-import fs from "fs";
 import path from "path";
 import os from "os";
 import mockFs from "mock-fs";
 import { MockFactory } from "../../../test/mockFactory";
 import { SimpleFileTokenCache } from "./simpleFileTokenCache";
+let fs;
+jest.isolateModules(() => {
+  fs = require("fs");
+});
 
 describe("Simple File Token Cache", () => {
   const tokenFilePath = "slsTokenCache.json";

--- a/src/plugins/offline/azureOfflinePlugin.ts
+++ b/src/plugins/offline/azureOfflinePlugin.ts
@@ -31,6 +31,10 @@ export class AzureOfflinePlugin extends AzureBasePlugin {
               nocleanup: {
                 usage: "Do not clean up offline files after finishing process",
                 shortcut: "n",
+              },
+              spawnargs: {
+                usage: "Arguments to add to spawned 'func host start' process",
+                shortcut: "a"
               }
             }
           },
@@ -51,6 +55,10 @@ export class AzureOfflinePlugin extends AzureBasePlugin {
           nocleanup: {
             usage: "Do not clean up offline files after finishing process",
             shortcut: "n",
+          },
+          spawnargs: {
+            usage: "Arguments to add to spawned 'func host start' process",
+            shortcut: "a"
           }
         }
       }

--- a/src/plugins/package/azurePackagePlugin.test.ts
+++ b/src/plugins/package/azurePackagePlugin.test.ts
@@ -84,5 +84,28 @@ describe("Azure Package Plugin", () => {
       expect(PackageService.prototype.cleanUpServerlessDir).not.toBeCalled();
       expect(sls.cli.log).lastCalledWith("No need to clean up generated folders & files. Using pre-existing package");
     });
-  })
+  });
+
+  describe("Linux", () => {
+    let pythonPlugin: AzurePackagePlugin;
+    const artifactHook = "package:createDeploymentArtifacts";
+
+    beforeEach(() => {
+      const sls = MockFactory.createTestServerless();
+      sls.service.provider["os"] = "linux";
+      pythonPlugin = new AzurePackagePlugin(sls, {} as any);
+      PackageService.prototype.createPackage = jest.fn();
+    });
+
+    it("replaces existing hook for creating artifact if python runtime", async () => {
+      expect(pythonPlugin.hooks[artifactHook]).toBeTruthy();
+      await invokeHook(pythonPlugin, "package:createDeploymentArtifacts");
+      expect(PackageService.prototype.createPackage).toBeCalled();
+    });
+
+    it("does not replace existing hook if node runtime", async () => {
+      const defaultPlugin = new AzurePackagePlugin(MockFactory.createTestServerless(), {} as any);
+      expect(defaultPlugin.hooks[artifactHook]).toBeFalsy();
+    })
+  });
 });

--- a/src/plugins/package/azurePackagePlugin.ts
+++ b/src/plugins/package/azurePackagePlugin.ts
@@ -1,6 +1,6 @@
 
 import Serverless from "serverless";
-import { ServerlessCliCommand } from "../../models/serverless";
+import { ServerlessCliCommand, FunctionAppOS } from "../../models/serverless";
 import AzureProvider from "../../provider/azureProvider";
 import { PackageService } from "../../services/packageService";
 import { AzureBasePlugin } from "../azureBasePlugin";
@@ -8,6 +8,7 @@ import { AzureBasePlugin } from "../azureBasePlugin";
 export class AzurePackagePlugin extends AzureBasePlugin {
   private bindingsCreated: boolean = false;
   public provider: AzureProvider;
+  private isLinuxTarget: boolean;
 
   public constructor(serverless: Serverless, options: Serverless.Options) {
     super(serverless, options);
@@ -16,6 +17,8 @@ export class AzurePackagePlugin extends AzureBasePlugin {
       "before:webpack:package:packageModules": this.webpack.bind(this),
       "after:package:finalize": this.finalize.bind(this),
     };
+    const { provider } = this.serverless.service;
+    this.isLinuxTarget = provider["os"] === FunctionAppOS.LINUX || provider.runtime.includes("python")
     if (this.isLinuxTarget) {
       /**
        * Replacing lifecycle event to build a deployment artifact with our own

--- a/src/services/armService.test.ts
+++ b/src/services/armService.test.ts
@@ -258,11 +258,13 @@ describe("Arm Service", () => {
 
       sls.service.provider["environment"] = environmentConfig
       sls.service.provider.runtime = "nodejs10.x";
+      sls.service.provider["os"] = "windows";
 
       const deployment = await service.createDeploymentFromType(ArmTemplateType.Consumption);
       await service.deployTemplate(deployment);
 
-      const appSettings: any[] = jsonpath.query(deployment.template, "$.resources[?(@.kind==\"functionapp\")].properties.siteConfig.appSettings[*]");
+      const appSettings: any[] = jsonpath.query(deployment.template, "$.resources[?(@.type==\"Microsoft.Web/sites\")].properties.siteConfig.appSettings[*]");
+     
       expect(appSettings.find((setting) => setting.name === "PARAM_1")).toEqual({ name: "PARAM_1", value: environmentConfig.PARAM_1 });
       expect(appSettings.find((setting) => setting.name === "PARAM_2")).toEqual({ name: "PARAM_2", value: environmentConfig.PARAM_2 });
       expect(appSettings.find((setting) => setting.name === "PARAM_3")).toEqual({ name: "PARAM_3", value: environmentConfig.PARAM_3 });

--- a/src/services/armService.ts
+++ b/src/services/armService.ts
@@ -231,7 +231,7 @@ export class ArmService extends BaseService {
 
       // This is a json path expression
       // Learn more @ https://goessner.net/articles/JsonPath/index.html#e2
-      const appSettingsPath = "$.resources[?(@.kind==\"functionapp\")].properties.siteConfig.appSettings";
+      const appSettingsPath = "$.resources[?(@.type==\"Microsoft.Web/sites\")].properties.siteConfig.appSettings";
 
       // Merges serverless yaml environment configuration into the app settings of the template
       jsonpath.apply(deployment.template, appSettingsPath, function (appSettingsList) {

--- a/src/services/baseService.test.ts
+++ b/src/services/baseService.test.ts
@@ -4,10 +4,7 @@ import { ServerlessAzureOptions } from "../models/serverless";
 import { MockFactory } from "../test/mockFactory";
 import { BaseService } from "./baseService";
 
-let fs;
-jest.isolateModules(() => {
-  fs = require("fs");
-});
+import fs from "fs";
 
 jest.mock("axios", () => jest.fn());
 import axios from "axios";

--- a/src/services/baseService.test.ts
+++ b/src/services/baseService.test.ts
@@ -1,9 +1,13 @@
-import fs from "fs";
 import mockFs from "mock-fs";
 import Serverless from "serverless";
 import { ServerlessAzureOptions } from "../models/serverless";
 import { MockFactory } from "../test/mockFactory";
 import { BaseService } from "./baseService";
+
+let fs;
+jest.isolateModules(() => {
+  fs = require("fs");
+});
 
 jest.mock("axios", () => jest.fn());
 import axios from "axios";

--- a/src/services/baseService.ts
+++ b/src/services/baseService.ts
@@ -4,7 +4,7 @@ import fs from "fs";
 import request from "request";
 import Serverless from "serverless";
 import { StorageAccountResource } from "../armTemplates/resources/storageAccount";
-import { ServerlessAzureConfig, ServerlessAzureOptions, ServerlessLogOptions } from "../models/serverless";
+import { ServerlessAzureConfig, ServerlessAzureOptions, ServerlessLogOptions, FunctionRuntime, SupportedRuntimeLanguage, FunctionAppOS } from "../models/serverless";
 import { constants } from "../shared/constants";
 import { Guard } from "../shared/guard";
 import { Utils } from "../shared/utils";
@@ -19,6 +19,9 @@ export abstract class BaseService {
   protected deploymentName: string;
   protected artifactName: string;
   protected storageAccountName: string;
+  protected runtime: FunctionRuntime;
+  protected pythonTarget: boolean;
+  protected linuxTarget: boolean;
   protected config: ServerlessAzureConfig;
   protected configService: ConfigService;
 
@@ -38,6 +41,9 @@ export abstract class BaseService {
     this.resourceGroup = this.configService.getResourceGroupName();
     this.deploymentName = this.configService.getDeploymentName();
     this.artifactName = this.configService.getArtifactName(this.deploymentName);
+    this.runtime = this.configService.getRuntime();
+    this.pythonTarget = this.runtime.language === SupportedRuntimeLanguage.PYTHON;
+    this.linuxTarget = this.configService.getOs() === FunctionAppOS.LINUX;
     this.storageAccountName = StorageAccountResource.getResourceName(this.config);
 
     if (!this.credentials && authenticate) {

--- a/src/services/baseService.ts
+++ b/src/services/baseService.ts
@@ -4,7 +4,7 @@ import fs from "fs";
 import request from "request";
 import Serverless from "serverless";
 import { StorageAccountResource } from "../armTemplates/resources/storageAccount";
-import { ServerlessAzureConfig, ServerlessAzureOptions, ServerlessLogOptions, FunctionRuntime, SupportedRuntimeLanguage, FunctionAppOS } from "../models/serverless";
+import { FunctionRuntime, ServerlessAzureConfig, ServerlessAzureOptions, ServerlessLogOptions } from "../models/serverless";
 import { constants } from "../shared/constants";
 import { Guard } from "../shared/guard";
 import { Utils } from "../shared/utils";
@@ -20,8 +20,6 @@ export abstract class BaseService {
   protected artifactName: string;
   protected storageAccountName: string;
   protected runtime: FunctionRuntime;
-  protected pythonTarget: boolean;
-  protected linuxTarget: boolean;
   protected config: ServerlessAzureConfig;
   protected configService: ConfigService;
 
@@ -42,8 +40,6 @@ export abstract class BaseService {
     this.deploymentName = this.configService.getDeploymentName();
     this.artifactName = this.configService.getArtifactName(this.deploymentName);
     this.runtime = this.configService.getRuntime();
-    this.pythonTarget = this.runtime.language === SupportedRuntimeLanguage.PYTHON;
-    this.linuxTarget = this.configService.getOs() === FunctionAppOS.LINUX;
     this.storageAccountName = StorageAccountResource.getResourceName(this.config);
 
     if (!this.credentials && authenticate) {

--- a/src/services/configService.ts
+++ b/src/services/configService.ts
@@ -217,7 +217,8 @@ export class ConfigService {
     ) || AzureNamingService.getResourceName(options);
     
     const functionRuntime = this.getFunctionRuntime(runtime);
-    if (functionRuntime.language === SupportedRuntimeLanguage.PYTHON) {
+    if (functionRuntime.language === SupportedRuntimeLanguage.PYTHON && os !== FunctionAppOS.LINUX) {
+      this.serverless.cli.log("Python functions can ONLY run on Linux Function Apps. Switching now");
       config.provider.os = FunctionAppOS.LINUX;
     } 
 

--- a/src/services/configService.ts
+++ b/src/services/configService.ts
@@ -3,7 +3,7 @@ import Serverless from "serverless";
 import Service from "serverless/classes/Service";
 import configConstants from "../config";
 import { DeploymentConfig, FunctionRuntime, ServerlessAzureConfig, 
-  ServerlessAzureFunctionConfig, SupportedRuntimeLanguage } from "../models/serverless";
+  ServerlessAzureFunctionConfig, SupportedRuntimeLanguage, FunctionAppOS } from "../models/serverless";
 import { constants } from "../shared/constants";
 import { Guard } from "../shared/guard";
 import { Utils } from "../shared/utils";
@@ -114,8 +114,15 @@ export class ConfigService {
   /**
    * Function runtime configuration
    */
-  public getFunctionRuntime(): FunctionRuntime {
+  public getRuntime(): FunctionRuntime {
     return this.config.provider.functionRuntime;
+  }
+
+  /**
+   * Operating system for function app
+   */
+  public getOs(): FunctionAppOS {
+    return this.config.provider.os;
   }
 
   /**
@@ -123,7 +130,7 @@ export class ConfigService {
    * @param config Current Serverless configuration
    */
   private setDefaultValues(config: ServerlessAzureConfig) {
-    const { awsRegion, region, stage, prefix } = configConstants.defaults;
+    const { awsRegion, region, stage, prefix, os } = configConstants.defaults;
     const providerRegion = config.provider.region;
 
     if (!providerRegion || providerRegion === awsRegion) {
@@ -136,6 +143,10 @@ export class ConfigService {
 
     if (!config.provider.prefix) {
       config.provider.prefix = prefix;
+    }
+
+    if (!config.provider.os) {
+      config.provider.os = os;
     }
   }
 
@@ -161,7 +172,8 @@ export class ConfigService {
       tenantId,
       appId,
       deployment,
-      runtime
+      runtime,
+      os
     } = config.provider;
 
     const options: AzureNamingServiceOptions = {
@@ -184,29 +196,30 @@ export class ConfigService {
         || tenantId,
       appId: this.getOption(constants.variableKeys.appId)
         || process.env.AZURE_CLIENT_ID
-        || appId
+        || appId,
     }
     config.provider.resourceGroup = (
       this.getOption("resourceGroup", config.provider.resourceGroup)
     ) || AzureNamingService.getResourceName(options);
+    
+    const functionRuntime = this.getFunctionRuntime(runtime);
+    if (functionRuntime.language === SupportedRuntimeLanguage.PYTHON) {
+      config.provider.os = FunctionAppOS.LINUX;
+    } 
 
-    // Get property from `runFromBlobUrl` for backwards compatibility
-    if (deployment && deployment.external === undefined && deployment["runFromBlobUrl"] !== undefined) {
-      deployment.external = deployment["runFromBlobUrl"];
-    }
+    config.provider.functionRuntime = functionRuntime;
 
     config.provider.deployment = {
       ...configConstants.deploymentConfig,
-      ...deployment
+      ...deployment,
+      external: (os === FunctionAppOS.LINUX),
     }
-
-    config.provider.functionRuntime = this.getRuntime(runtime);
 
     this.serverless.variables[constants.variableKeys.providerConfig] = config.provider;
     return config;
   }
 
-  private getRuntime(runtime: string): FunctionRuntime {
+  private getFunctionRuntime(runtime: string): FunctionRuntime {
     Guard.null(runtime, "runtime", "Runtime version not specified in serverless.yml");
 
     const versionMatch = runtime.match(/([0-9]+\.)+[0-9]*x?/);

--- a/src/services/configService.ts
+++ b/src/services/configService.ts
@@ -126,6 +126,20 @@ export class ConfigService {
   }
 
   /**
+   * Function app configured to run on Python
+   */
+  public isPythonTarget(): boolean {
+    return this.config.provider.functionRuntime.language === SupportedRuntimeLanguage.PYTHON;
+  }
+
+  /**
+   * Function app configured to run on Linux
+   */
+  public isLinuxTarget(): boolean {
+    return this.getOs() === FunctionAppOS.LINUX
+  }
+
+  /**
    * Set any default values required for service
    * @param config Current Serverless configuration
    */

--- a/src/services/coreToolsService.ts
+++ b/src/services/coreToolsService.ts
@@ -3,11 +3,12 @@ import { Utils } from "../shared/utils"
 import configConstants from "../config";
 
 export class CoreToolsService {
-  public static async start(serverless: Serverless, onFinish: () => void) {
+  public static async start(serverless: Serverless, onFinish: () => void, additionalArgs?: string[]) {
+    const defaultArgs = configConstants.func.start;
     await Utils.spawn({
       serverless: serverless,
       command: configConstants.func.command,
-      commandArgs: configConstants.func.start,
+      commandArgs: (additionalArgs) ? defaultArgs.concat(additionalArgs) : defaultArgs,
       onSigInt: onFinish
     });
   }

--- a/src/services/coreToolsService.ts
+++ b/src/services/coreToolsService.ts
@@ -1,0 +1,45 @@
+import Serverless from "serverless";
+import { Utils } from "../shared/utils"
+import configConstants from "../config";
+
+export class CoreToolsService {
+  public static async start(serverless: Serverless, onFinish: () => void) {
+    await Utils.spawn({
+      serverless: serverless,
+      command: configConstants.func.command,
+      commandArgs: configConstants.func.start,
+      onSigInt: onFinish
+    });
+  }
+
+  public static async pack(serverless: Serverless) {
+    await Utils.spawn({
+      serverless: serverless,
+      command: configConstants.func.command,
+      commandArgs: configConstants.func.pack,
+      stdio: "ignore"
+    });
+  }
+
+  public static async publish(serverless: Serverless, functionAppName: string) {
+    /**
+     * This is where we would invoke the publish command from Azure Functions core tools.
+     * Currently, it fails because it's not able to make a call to the Azure CLI from
+     * within a child process. If we were to do it, it would look like:
+     * 
+       await Utils.spawn({
+         serverless: serverless,
+         command: configConstants.func.command,
+         commandArgs: configConstants.func.publish.concat(functionAppName),
+       });
+     * 
+     * As a workaround, we provide the exact command for users to run in order to publish
+     * their function app and optionally clean up their workspace
+     */
+    const { func } = configConstants;
+    serverless.cli.log(`Run command: \n\n ${func.command} ${func.publish
+      .concat(functionAppName)
+      .join(" ")} && sls offline cleanup\n\n`
+    )
+  }
+}

--- a/src/services/funcService.test.ts
+++ b/src/services/funcService.test.ts
@@ -1,9 +1,13 @@
-import fs from "fs";
 import mockFs from "mock-fs";
 import rimraf from "rimraf";
 import { MockFactory } from "../test/mockFactory";
 import Serverless from "serverless";
 import { FuncService } from "./funcService";
+
+let fs;
+jest.isolateModules(() => {
+  fs = require("fs");
+});
 
 describe("Azure Func Service", () => {
 

--- a/src/services/funcService.test.ts
+++ b/src/services/funcService.test.ts
@@ -4,10 +4,7 @@ import { MockFactory } from "../test/mockFactory";
 import Serverless from "serverless";
 import { FuncService } from "./funcService";
 
-let fs;
-jest.isolateModules(() => {
-  fs = require("fs");
-});
+import fs from "fs";
 
 describe("Azure Func Service", () => {
 

--- a/src/services/functionAppService.test.ts
+++ b/src/services/functionAppService.test.ts
@@ -410,7 +410,7 @@ describe("Function App Service", () => {
         return {
           properties: appSettings
         }
-      });
+      }) as any;
       AzureBlobStorageService.prototype.generateBlobSasTokenUrl = jest.fn(() => Promise.resolve(sasUrl));
     });
 
@@ -418,41 +418,18 @@ describe("Function App Service", () => {
       (FunctionAppService.prototype.updateFunctionAppSetting as any).mockRestore();
     });
 
-    it("updates WEBSITE_RUN_FROM_PACKAGE with SAS URL if configured to run from blob", async () => {
+    it("does not upload directly to function app if configured to run on linux", async () => {
       const newSlsService = MockFactory.createTestService();
-      newSlsService.provider["deployment"] = {
-        external: true,
-      }
+      newSlsService.provider["os"] = "linux";
       const service = createService(MockFactory.createTestServerless({
         service: newSlsService,
       }));
+      FunctionAppService.prototype.uploadZippedArtifactToFunctionApp = jest.fn();
       await service.uploadFunctions(app);
-      expect(AzureBlobStorageService.prototype.generateBlobSasTokenUrl).toBeCalled();
-      expect(FunctionAppService.prototype.updateFunctionAppSetting).toBeCalledWith(
-        app,
-        "WEBSITE_RUN_FROM_PACKAGE",
-        sasUrl
-      );
-    });
-
-    it("does not upload directly to function app if configured to run from blob", async () => {
-      const newSlsService = MockFactory.createTestService();
-      newSlsService.provider["deployment"] = {
-        external: true,
-      }
-      const service = createService(MockFactory.createTestServerless({
-        service: newSlsService,
-      }));
-      FunctionAppService.prototype.uploadZippedArfifactToFunctionApp = jest.fn();
-      await service.uploadFunctions(app);
-      expect(AzureBlobStorageService.prototype.generateBlobSasTokenUrl).toBeCalled();
-      expect(FunctionAppService.prototype.updateFunctionAppSetting).toBeCalledWith(
-        app,
-        "WEBSITE_RUN_FROM_PACKAGE",
-        sasUrl
-      );
-      expect(FunctionAppService.prototype.uploadZippedArfifactToFunctionApp).not.toBeCalled();
-      (FunctionAppService.prototype.uploadZippedArfifactToFunctionApp as any).mockRestore();
+      expect(AzureBlobStorageService.prototype.uploadFile).toBeCalled();
+      expect(AzureBlobStorageService.prototype.generateBlobSasTokenUrl).not.toBeCalled();
+      expect(FunctionAppService.prototype.uploadZippedArtifactToFunctionApp).not.toBeCalled();
+      (FunctionAppService.prototype.uploadZippedArtifactToFunctionApp as any).mockRestore();
     });
 
     it("uploads directly to function app if not configured to run from blob", async () => {
@@ -464,11 +441,11 @@ describe("Function App Service", () => {
         service: newSlsService,
       });
       const service = createService(sls);
-      FunctionAppService.prototype.uploadZippedArfifactToFunctionApp = jest.fn();
+      FunctionAppService.prototype.uploadZippedArtifactToFunctionApp = jest.fn();
       await service.uploadFunctions(app);
       expect(AzureBlobStorageService.prototype.generateBlobSasTokenUrl).not.toBeCalled();
-      expect(FunctionAppService.prototype.uploadZippedArfifactToFunctionApp).toBeCalled();
-      (FunctionAppService.prototype.uploadZippedArfifactToFunctionApp as any).mockRestore();
+      expect(FunctionAppService.prototype.uploadZippedArtifactToFunctionApp).toBeCalled();
+      (FunctionAppService.prototype.uploadZippedArtifactToFunctionApp as any).mockRestore();
     });
 
     it("does not generate SAS URL or update WEBSITE_RUN_FROM_PACKAGE if not configured to run from blob", async() => {

--- a/src/services/functionAppService.ts
+++ b/src/services/functionAppService.ts
@@ -12,7 +12,7 @@ import { ArmService } from "./armService";
 import { AzureBlobStorageService } from "./azureBlobStorageService";
 import { BaseService } from "./baseService";
 import configConstants from "../config";
-import { CoreToolsService } from "./coreToolsService";
+import { PublishService } from "./publishService";
 
 export class FunctionAppService extends BaseService {
   private static readonly retryCount: number = 30;
@@ -162,15 +162,8 @@ export class FunctionAppService extends BaseService {
     // Uploaded to blob storage as artifact for future reference
     await this.uploadZippedArtifactToBlobStorage(functionZipFile);
 
-    if (this.linuxTarget) {
-      /**
-       * When core tools supports publishing an existing package,
-       * use `functionZipFile` here
-       */
-      await CoreToolsService.publish(this.serverless, functionApp.name);
-    } else {
-      await this.publish(functionApp, functionZipFile);
-    }
+    const publishService = new PublishService(this.serverless, this.options, this);
+    await publishService.publish(functionApp, functionZipFile)
   }
 
   /**

--- a/src/services/offlineService.test.ts
+++ b/src/services/offlineService.test.ts
@@ -214,6 +214,25 @@ describe("Offline Service", () => {
     expect(rmdirCalls[1][0]).toBe("goodbye");
   });
 
+  it("adds additional arguments to spawned process if passed through Serverless args", async () => {
+    Object.defineProperty(process, "platform", {
+      value: "darwin",
+      writable: true,
+    });
+
+    const sls = MockFactory.createTestServerless();
+
+    const service = createService(sls, { "spawnargs": "--cors *"});
+
+    await service.start();
+
+    const calls = mySpawn.calls;
+    expect(calls).toHaveLength(1);
+    const call = calls[0];
+    expect(call.command).toEqual(path.join("node_modules", ".bin", "func"));
+    expect(call.args).toEqual(["host", "start", "--cors", "*"]);
+  });
+
   it("does not clean up after offline call if specified in options", async () => {
 
     Object.defineProperty(process, "platform", {

--- a/src/services/offlineService.test.ts
+++ b/src/services/offlineService.test.ts
@@ -5,10 +5,7 @@ import Serverless from "serverless";
 import { MockFactory } from "../test/mockFactory";
 import { OfflineService } from "./offlineService";
 
-let fs;
-jest.isolateModules(() => {
-  fs = require("fs");
-});
+import fs from "fs";
 
 describe("Offline Service", () => {
   let mySpawn;

--- a/src/services/offlineService.ts
+++ b/src/services/offlineService.ts
@@ -48,6 +48,7 @@ export class OfflineService extends BaseService {
    * Spawn `func host start` from core func tools
    */
   public async start() {
+    const args: string = this.getOption("spawnargs");
     await CoreToolsService.start(this.serverless, async () => {
       try {
         if (this.getOption("nocleanup")) {
@@ -61,6 +62,6 @@ export class OfflineService extends BaseService {
       } finally {
         process.exit();
       }
-    });
+    }, (args) ? args.split(" ") : undefined);
   }
 }

--- a/src/services/packageService.test.ts
+++ b/src/services/packageService.test.ts
@@ -7,10 +7,7 @@ import { FunctionMetadata } from "../shared/utils";
 import { MockFactory } from "../test/mockFactory";
 import { PackageService } from "./packageService";
 
-let fs;
-jest.isolateModules(() => {
-  fs = require("fs");
-})
+import fs from "fs";
 
 jest.mock("rimraf");
 

--- a/src/services/packageService.test.ts
+++ b/src/services/packageService.test.ts
@@ -277,7 +277,6 @@ describe("Package Service", () => {
       mockFs.restore();
       calledWithArgs(writeSpy, [
         ".funcignore",
-        ...functions.map((name) => `${name}${path.sep}__init__.py`),
         ...functions.map((name) => `${name}${path.sep}function.json`)
       ]);
       writeSpy.mockRestore();
@@ -310,14 +309,12 @@ describe("Package Service", () => {
           "__pycache__": {
             "file.pyc": ""
           },
-          "__init__.py": "",
           "function.json": ""
         },
         "goodbye" : {
           "__pycache__": {
             "file.pyc": ""
           },
-          "__init__.py": "",
           "function.json": "",
         },
       });
@@ -325,7 +322,6 @@ describe("Package Service", () => {
       mockFs.restore();
       calledWithArgs(unlinkSpy, [
         ".funcignore",
-        ...functions.map((name) => `${name}${path.sep}__init__.py`),
         ...functions.map((name) => `${name}${path.sep}function.json`)
       ]);
       unlinkSpy.mockRestore();

--- a/src/services/packageService.test.ts
+++ b/src/services/packageService.test.ts
@@ -253,8 +253,6 @@ describe("Package Service", () => {
     let functions: string[];
 
     beforeEach(() => {
-      
-      
       mySpawn = mockSpawn();
       require("child_process").spawn = mySpawn;
       mySpawn.setDefault(mySpawn.simple(0, "Exit code"));

--- a/src/services/packageService.ts
+++ b/src/services/packageService.ts
@@ -90,7 +90,6 @@ export class PackageService extends BaseService {
   public cleanUp() {
     const functionFilesToRemove = [
       "function.json",
-      "__init__.py"
     ];
 
     const functionFoldersToRemove = [
@@ -143,10 +142,6 @@ export class PackageService extends BaseService {
     const functionDirPath = this.makeFunctionDir(functionName);
 
     fs.writeFileSync(path.join(functionDirPath, "function.json"), this.stringify(functionJSON));
-
-    if (this.runtime.language === SupportedRuntimeLanguage.PYTHON) {
-      fs.writeFileSync(path.join(functionDirPath, "__init__.py"), "");
-    }
     return Promise.resolve();
   }
 

--- a/src/services/packageService.ts
+++ b/src/services/packageService.ts
@@ -4,6 +4,9 @@ import rimraf from "rimraf";
 import Serverless from "serverless";
 import { FunctionMetadata, Utils } from "../shared/utils";
 import { BaseService } from "./baseService";
+import { SupportedRuntimeLanguage } from "../models/serverless";
+import configConstants from "../config";
+import { CoreToolsService } from "./coreToolsService";
 
 /**
  * Adds service packing support
@@ -30,8 +33,24 @@ export class PackageService extends BaseService {
         const metaData = await Utils.getFunctionMetaData(functionName, this.serverless);
         return this.createBinding(functionName, metaData);
       });
+    this.generateFuncIgnore();
 
     await Promise.all(createEventsPromises);
+  }
+
+  public async createPackage() {
+    this.log("Invoking core tools to build package...")
+
+    await CoreToolsService.pack(this.serverless);
+    
+    const { servicePath } = this.serverless.config;
+    const artifact = path.join(servicePath, path.basename(process.cwd()) + ".zip");
+    const serverlessDir = path.join(servicePath, ".serverless")
+    if (!fs.existsSync(serverlessDir)) {
+      fs.mkdirSync(serverlessDir);
+    }
+    const artifactPath = path.join(serverlessDir, `${this.serviceName}.zip`);
+    fs.renameSync(artifact, artifactPath);
   }
 
   /**
@@ -69,19 +88,49 @@ export class PackageService extends BaseService {
    * Cleans up generated function.json files after packaging has completed
    */
   public cleanUp() {
+    const functionFilesToRemove = [
+      "function.json",
+      "__init__.py"
+    ];
+
+    const functionFoldersToRemove = [
+      "__pycache__"
+    ]
+
+    const rootFilesToRemove = [
+      ".funcignore"
+    ]
+
     this.serverless.service.getAllFunctions().map((functionName) => {
       // Delete function.json if exists in function folder
-      const filePath = path.join(functionName, "function.json");
-      if (fs.existsSync(filePath)) {
-        fs.unlinkSync(filePath);
-      }
 
+      functionFilesToRemove.forEach((fileToRemove) => {
+        const filePath = path.join(functionName, fileToRemove);
+        if (fs.existsSync(filePath)) {
+          fs.unlinkSync(filePath);
+        }
+      });
+
+      functionFoldersToRemove.forEach((folderToRemove) => {
+        const folderPath = path.join(functionName, folderToRemove);
+        if (fs.existsSync(folderPath)) {
+          rimraf.sync(folderPath);
+        }
+      });
+      
       // Delete function folder if empty
       const items = fs.readdirSync(functionName);
       if (items.length === 0) {
         fs.rmdirSync(functionName);
       }
     });
+
+    for (const file of rootFilesToRemove) {
+      const filePath = path.join(this.serverless.config.servicePath, file);
+      if (fs.existsSync(filePath)) {
+        fs.unlinkSync(filePath);
+      }
+    }    
 
     return Promise.resolve();
   }
@@ -90,9 +139,29 @@ export class PackageService extends BaseService {
    * Creates the function.json for for the specified function
    */
   public createBinding(functionName: string, functionMetadata: FunctionMetadata) {
-    const functionJSON = functionMetadata.params.functionsJson;
-    functionJSON.entryPoint = functionMetadata.entryPoint;
-    functionJSON.scriptFile = functionMetadata.handlerPath;
+    const functionJSON = this.getFunctionJson(functionName, functionMetadata);
+    const functionDirPath = this.makeFunctionDir(functionName);
+
+    fs.writeFileSync(path.join(functionDirPath, "function.json"), this.stringify(functionJSON));
+
+    if (this.runtime.language === SupportedRuntimeLanguage.PYTHON) {
+      fs.writeFileSync(path.join(functionDirPath, "__init__.py"), "");
+    }
+    return Promise.resolve();
+  }
+
+  private getFunctionJson(functionName: string, functionMetadata: FunctionMetadata) {
+    const functionJSON = functionMetadata.params.functionJson;
+    const { entryPoint, handlerPath } = functionMetadata;
+    functionJSON.entryPoint = entryPoint;
+    if (this.pythonTarget) {
+      const index = (functionJSON.bindings as any[])
+        .findIndex((binding) => (!binding.direction || binding.direction === "out"));
+      functionJSON.bindings[index].name = "$return";
+    } else {
+    }
+    functionJSON.scriptFile = handlerPath;
+
     const functionObject = this.configService.getFunctionConfig()[functionName];
     const bindingAzureSettings = Utils.getIncomingBindingConfig(functionObject)["x-azure-settings"];
 
@@ -104,14 +173,27 @@ export class PackageService extends BaseService {
       functionJSON.bindings[index].route = bindingAzureSettings.route;
     }
 
+    return functionJSON;
+  }
+
+  private makeFunctionDir(functionName: string) {
     const functionDirPath = path.join(this.serverless.config.servicePath, functionName);
     if (!fs.existsSync(functionDirPath)) {
       fs.mkdirSync(functionDirPath);
     }
+    return functionDirPath;
+  }
 
-    const functionJsonString = this.stringify(functionJSON);
-    fs.writeFileSync(path.join(functionDirPath, "function.json"), functionJsonString);
-
-    return Promise.resolve();
+  private generateFuncIgnore() {
+    const exclude = this.config.package.exclude || []
+    fs.writeFileSync(
+      path.join(this.serverless.config.servicePath, ".funcignore"),
+      exclude
+        .concat(configConstants.defaultFuncIgnore)
+        .concat([
+          this.configService.getConfigFile()
+        ])
+        .join("\n")  
+    )
   }
 }

--- a/src/services/packageService.ts
+++ b/src/services/packageService.ts
@@ -154,7 +154,7 @@ export class PackageService extends BaseService {
     const functionJSON = functionMetadata.params.functionJson;
     const { entryPoint, handlerPath } = functionMetadata;
     functionJSON.entryPoint = entryPoint;
-    if (this.pythonTarget) {
+    if (this.configService.isPythonTarget()) {
       const index = (functionJSON.bindings as any[])
         .findIndex((binding) => (!binding.direction || binding.direction === "out"));
       functionJSON.bindings[index].name = "$return";

--- a/src/services/publishService.test.ts
+++ b/src/services/publishService.test.ts
@@ -1,0 +1,71 @@
+import MockAdapter from "axios-mock-adapter";
+import mockFs from "mock-fs";
+import Serverless from "serverless";
+import { ServerlessAzureConfig } from "../models/serverless";
+import { MockFactory } from "../test/mockFactory";
+import { PublishService } from "./publishService";
+
+jest.mock("./coreToolsService");
+import { CoreToolsService } from "./coreToolsService";
+
+jest.mock("./functionAppService");
+import { FunctionAppService } from "./functionAppService";
+
+describe("Publish Service", () => {
+
+  const app = MockFactory.createTestSite();
+  const functionAppFileName = "functionApp.zip";
+  const baseUrl = "https://management.azure.com"
+  const slsService = MockFactory.createTestService();
+  const config: ServerlessAzureConfig = slsService as any;
+  const subscriptionId = "subId";
+  
+  let axiosMock: MockAdapter;
+
+  const syncTriggersUrl = `${baseUrl}/subscriptions/${subscriptionId}` +
+    `/resourceGroups/${config.provider.resourceGroup}/providers/Microsoft.Web/sites/${app.name}` +
+    "/syncfunctiontriggers?api-version=2016-08-01";
+  const syncTriggersResponse = "sync triggers success";
+
+  function createService(sls?: Serverless, options?: Serverless.Options) {
+    return new PublishService(
+      sls || MockFactory.createTestServerless(),
+      options || {} as any
+    )
+  }
+
+  beforeEach(() => {
+    const fsConfig = {}
+    fsConfig[functionAppFileName] = "";
+    mockFs(fsConfig);
+    
+    // Sync Triggers
+    axiosMock.onPost(syncTriggersUrl).reply(200, syncTriggersResponse);
+  });
+
+  afterEach(() => {
+    mockFs.restore();
+  })
+
+  xit("calls core tools for linux publishing", async () => {
+
+  });
+
+  xit("does not call core tools for windows publishing", async () => {
+    const newSlsService = MockFactory.createTestService();
+    newSlsService.provider["os"] = "windows";
+    const service = createService(MockFactory.createTestServerless({
+      service: newSlsService,
+    }));
+
+    await service.publish(app, functionAppFileName);
+   
+    expect(CoreToolsService.publish).not.toBeCalled();
+    // FunctionAppService.prototype.uploadZippedArtifactToFunctionApp = jest.fn();
+    // await service.uploadFunctions(app);
+    // expect(AzureBlobStorageService.prototype.uploadFile).toBeCalled();
+    // expect(AzureBlobStorageService.prototype.generateBlobSasTokenUrl).not.toBeCalled();
+    // expect(FunctionAppService.prototype.uploadZippedArtifactToFunctionApp).not.toBeCalled();
+    // (FunctionAppService.prototype.uploadZippedArtifactToFunctionApp as any).mockRestore();
+  });
+});

--- a/src/services/publishService.ts
+++ b/src/services/publishService.ts
@@ -1,0 +1,107 @@
+import { Site } from "@azure/arm-appservice/esm/models";
+import fs from "fs";
+import Serverless from "serverless";
+import configConstants from "../config";
+import { FunctionAppOS } from "../models/serverless";
+import { Guard } from "../shared/guard";
+import { AzureBlobStorageService } from "./azureBlobStorageService";
+import { BaseService } from "./baseService";
+import { CoreToolsService } from "./coreToolsService";
+import { FunctionAppService } from "./functionAppService";
+
+export class PublishService extends BaseService {
+
+  private blobService: AzureBlobStorageService;
+
+  public constructor(serverless: Serverless, options: Serverless.Options) {
+    super(serverless, options);
+    this.blobService = new AzureBlobStorageService(serverless, options);
+  }
+
+  public async publish(functionApp: Site, functionZipFile: string) {
+    if (this.config.provider.os === FunctionAppOS.LINUX) {
+      await this.linuxPublish(functionApp);
+    } else {
+      await this.windowsPublish(functionApp, functionZipFile);
+    }
+  }
+
+  private async windowsPublish(functionApp: Site, functionZipFile: string) {
+    const functionAppService = new FunctionAppService(this.serverless, this.options);
+    
+    this.log("Deploying serverless functions...");
+    if (this.config.provider.deployment.external) {
+      this.log("Updating function app setting to run from external package...");
+      const sasUrl = await this.blobService.generateBlobSasTokenUrl(
+        this.config.provider.deployment.container,
+        this.artifactName
+      );
+      const response = await functionAppService.updateFunctionAppSetting(
+        functionApp,
+        configConstants.runFromPackageSetting,
+        sasUrl
+      );
+      await functionAppService.syncTriggers(functionApp, response.properties);
+    } else {
+      await this.uploadZippedArtifactToFunctionApp(functionApp, functionZipFile);
+    }
+
+    this.log("Deployed serverless functions:")
+    const serverlessFunctions = this.serverless.service.getAllFunctions();
+    const deployedFunctions = await functionAppService.listFunctions(functionApp);
+
+    // List functions that are part of the serverless yaml config
+    deployedFunctions.forEach((functionConfig) => {
+      if (serverlessFunctions.includes(functionConfig.name)) {
+        const httpConfig = functionAppService.getFunctionHttpTriggerConfig(functionApp, functionConfig);
+
+        if (httpConfig) {
+          const method = httpConfig.methods[0].toUpperCase();
+          this.log(`-> ${functionConfig.name}: [${method}] ${httpConfig.url}`);
+        }
+      }
+    });
+  }
+
+  private async linuxPublish(functionApp: Site) {
+    await CoreToolsService.publish(this.serverless, functionApp.name);
+  }
+
+  private async uploadZippedArtifactToFunctionApp(functionApp: Site, functionZipFile: string) {
+    const scmDomain = this.getScmDomain(functionApp);
+
+    this.log(`Deploying zip file to function app: ${functionApp.name}`);
+
+    if (!(functionZipFile && fs.existsSync(functionZipFile))) {
+      throw new Error("No zip file found for function app");
+    }
+
+    this.log(`-> Deploying service package @ ${functionZipFile}`);
+
+    // https://github.com/projectkudu/kudu/wiki/Deploying-from-a-zip-file-or-url
+    const requestOptions = {
+      method: "POST",
+      uri: `https://${scmDomain}/api/zipdeploy/`,
+      json: true,
+      headers: {
+        Authorization: `Bearer ${await this.getAccessToken()}`,
+        Accept: "*/*",
+        ContentType: "application/octet-stream",
+      }
+    };
+
+    await this.sendFile(requestOptions, functionZipFile);
+    this.log("-> Function package uploaded successfully");
+  }
+
+  /**
+   * Retrieves the SCM domain from the list of enabled domains within the app
+   * Note: The SCM domain exposes additional API calls from the standard REST APIs.
+   * @param functionApp The function app / web site
+   */
+  private getScmDomain(functionApp: Site) {
+    return functionApp.enabledHostNames.find((hostName: string) => {
+      return hostName.includes(".scm.") && hostName.endsWith(".azurewebsites.net");
+    });
+  }
+}

--- a/src/services/rollbackService.test.ts
+++ b/src/services/rollbackService.test.ts
@@ -6,10 +6,7 @@ import { MockFactory } from "../test/mockFactory";
 import { RollbackService } from "./rollbackService";
 import configConstants from "../config";
 
-let fs;
-jest.isolateModules(() => {
-  fs = require("fs");
-});
+import fs from "fs";
 
 jest.mock("./azureBlobStorageService");
 import { AzureBlobStorageService } from "./azureBlobStorageService";

--- a/src/services/rollbackService.test.ts
+++ b/src/services/rollbackService.test.ts
@@ -2,10 +2,14 @@ import mockFs from "mock-fs";
 import path from "path";
 import Serverless from "serverless";
 import { ArmDeployment, ArmParamType } from "../models/armTemplates";
-import { DeploymentConfig } from "../models/serverless";
 import { MockFactory } from "../test/mockFactory";
 import { RollbackService } from "./rollbackService";
-import fs from "fs";
+import configConstants from "../config";
+
+let fs;
+jest.isolateModules(() => {
+  fs = require("fs");
+});
 
 jest.mock("./azureBlobStorageService");
 import { AzureBlobStorageService } from "./azureBlobStorageService";
@@ -18,7 +22,6 @@ import { FunctionAppService } from "./functionAppService";
 
 jest.mock("./armService");
 import { ArmService } from "./armService";
-import configConstants from "../config";
 
 describe("Rollback Service", () => {
 
@@ -107,19 +110,17 @@ describe("Rollback Service", () => {
       artifactPath,
     );
     expect(FunctionAppService.prototype.get).toBeCalled();
-    expect(FunctionAppService.prototype.uploadZippedArfifactToFunctionApp).toBeCalledWith(
+    expect(FunctionAppService.prototype.uploadZippedArtifactToFunctionApp).toBeCalledWith(
       appStub,
       artifactPath
     );
     expect(unlinkSpy).toBeCalledWith(artifactPath);
+    unlinkSpy.mockRestore();
   });
 
   it("should deploy function app with SAS URL", async () => {
     const sls = MockFactory.createTestServerless();
-    const deploymentConfig: DeploymentConfig = {
-      external: true
-    }
-    sls.service.provider["deployment"] = deploymentConfig;
+    sls.service.provider["os"] = "linux";
     const service = createService(sls);
     await service.rollback();
     expect(AzureBlobStorageService.prototype.initialize).toBeCalled();
@@ -139,7 +140,8 @@ describe("Rollback Service", () => {
       artifactName
     );
     expect(FunctionAppService.prototype.get).not.toBeCalled();
-    expect(FunctionAppService.prototype.uploadZippedArfifactToFunctionApp).not.toBeCalled();
+    expect(FunctionAppService.prototype.uploadZippedArtifactToFunctionApp).not.toBeCalled();
     expect(unlinkSpy).not.toBeCalled();
+    unlinkSpy.mockRestore();
   });
 });

--- a/src/services/rollbackService.ts
+++ b/src/services/rollbackService.ts
@@ -98,7 +98,7 @@ export class RollbackService extends BaseService {
   private async redeployArtifact(artifactPath: string) {
     const functionAppService = new FunctionAppService(this.serverless, this.options);
     const functionApp = await functionAppService.get();
-    await functionAppService.uploadZippedArfifactToFunctionApp(functionApp, artifactPath);
+    await functionAppService.uploadZippedArtifactToFunctionApp(functionApp, artifactPath);
     if (fs.existsSync(artifactPath)) {
       fs.unlinkSync(artifactPath);
     }

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -28,6 +28,7 @@ export const constants = {
     appId: "appId",
     packageTimestamp: "packageTimestamp",
     azureCredentials: "azureCredentials",
+    os: "os",
   },
   runtimeExtensions: {
     node: ".js",

--- a/src/shared/utils.test.ts
+++ b/src/shared/utils.test.ts
@@ -1,8 +1,7 @@
-import path from "path";
 import Serverless from "serverless";
+import { ConfigService } from "../services/configService";
 import { MockFactory } from "../test/mockFactory";
 import { FunctionMetadata, Utils } from "./utils";
-import { ConfigService } from "../services/configService";
 
 describe("utils", () => {
   let sls: Serverless;
@@ -30,7 +29,7 @@ describe("utils", () => {
 
     const expectedMetadata: FunctionMetadata = {
       entryPoint: "handler",
-      handlerPath: path.normalize("../src/handlers/hello.js"),
+      handlerPath: "../src/handlers/hello.js",
       params: expect.anything(),
     };
 
@@ -53,7 +52,7 @@ describe("utils", () => {
 
     const expectedMetadata: FunctionMetadata = {
       entryPoint: "handler",
-      handlerPath: path.normalize("index.js"),
+      handlerPath: "index.js",
       params: expect.anything(),
     };
 
@@ -76,7 +75,7 @@ describe("utils", () => {
 
     const expectedMetadata: FunctionMetadata = {
       entryPoint: "handler",
-      handlerPath: path.normalize("../hello.js"),
+      handlerPath: "../hello.js",
       params: expect.anything(),
     };
 

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -1,14 +1,26 @@
-import { relative } from "path";
+import { relative, join } from "path";
 import Serverless from "serverless";
-import { ServerlessAzureFunctionConfig, ServerlessAzureConfig } from "../models/serverless";
+import { ServerlessAzureConfig, ServerlessAzureFunctionConfig } from "../models/serverless";
 import { BindingUtils } from "./bindings";
 import { constants } from "./constants";
 import { createInterface } from "readline"
+import { SpawnOptions, spawn, StdioOptions } from "child_process";
 
 export interface FunctionMetadata {
-  entryPoint: any;
-  handlerPath: any;
-  params: any;
+  entryPoint: string;
+  handlerPath: string;
+  params: {
+    functionJson: any;
+  };
+}
+
+export interface ServerlessSpawnOptions {
+  serverless: Serverless;
+  command: string;
+  commandArgs: string[];
+  silent?: boolean;
+  stdio?: StdioOptions;
+  onSigInt?: () => void;
 }
 
 export class Utils {
@@ -19,7 +31,7 @@ export class Utils {
     let bindingSettings = [];
     let bindingUserSettings = {};
     let bindingType;
-    const functionsJson = { disabled: false, bindings: [] };
+    const functionJson = { disabled: false, bindings: [] };
     const functionObject = serverless.service.getFunction(functionName);
     const handler = functionObject.handler;
     const events = functionObject["events"];
@@ -83,8 +95,8 @@ export class Utils {
       bindings.push(BindingUtils.getHttpOutBinding());
     }
 
-    functionsJson.bindings = bindings;
-    params.functionsJson = functionsJson;
+    functionJson.bindings = bindings;
+    params.functionJson = functionJson;
 
     let { handlerPath, entryPoint } = Utils.getEntryPointAndHandlerPath(handler, config);
     if (functionObject["scriptFile"]) {
@@ -93,7 +105,7 @@ export class Utils {
 
     return {
       entryPoint,
-      handlerPath: relative(functionName, handlerPath),
+      handlerPath: relative(functionName, handlerPath).replace(/\\/g, "/"),
       params: params
     };
   }
@@ -158,7 +170,7 @@ export class Utils {
   /**
    * Runs an operation with auto retry policy
    * @param operation The operation to run
-   * @param maxRetries The max number or retreis
+   * @param maxRetries The max number or retries
    * @param retryWaitInterval The time to wait between retries
    */
   public static async runWithRetry<T>(operation: (retry?: number) => Promise<T>, maxRetries: number = 3, retryWaitInterval: number = 1000) {
@@ -203,6 +215,56 @@ export class Utils {
       rl.question("", (answer: string) => {
         rl.close();
         resolve(answer);
+      })
+    });
+  }
+  
+  /*
+   * Spawn a Node child process with predefined environment variables
+   * @param command CLI Command - NO ARGS
+   * @param spawnArgs Array of arguments for CLI command
+   */
+  public static spawn(options: ServerlessSpawnOptions): Promise<void> {
+    const { serverless, commandArgs, onSigInt } = options;
+    const { command } = options;
+    // Run command from local node_modules
+    let localCommand = join(
+      serverless.config.servicePath,
+      "node_modules",
+      ".bin",
+      command
+    );
+    
+    // Append .cmd if running on windows
+    if (process.platform === "win32") {
+      localCommand += ".cmd";
+    }
+
+    const env = {
+      // Inherit environment from current process, most importantly, the PATH
+      ...process.env,
+      // Environment variables from serverless config are king
+      ...serverless.service.provider["environment"],
+    }
+    if (!options.silent) {
+      serverless.cli.log(`Spawning process '${command} ${commandArgs.join(" ")}'`);
+    }
+    return new Promise(async (resolve, reject) => {
+      const spawnOptions: SpawnOptions = { env, stdio: options.stdio || "inherit" };
+
+      const childProcess = spawn(localCommand, commandArgs, spawnOptions);
+
+      if (onSigInt) {
+        process.on("SIGINT", onSigInt);
+      }
+
+      childProcess.on("exit", (code, signal) => {
+        if (code === 0) {
+          resolve();
+        } else {
+          serverless.cli.log("Got an exit")
+          reject(`${code} ${signal}`);
+        }
       });
     });
   }

--- a/src/test/mockFactory.ts
+++ b/src/test/mockFactory.ts
@@ -63,7 +63,11 @@ export class MockFactory {
       provider: MockFactory.createTestAzureServiceProvider(),
       service: serviceName,
       artifact: "app.zip",
-      functions
+      functions,
+      package: {
+        exclude: [],
+        include: [],
+      }
     } as any as Service;
   }
 
@@ -666,7 +670,7 @@ export class MockFactory {
       cliOptions: null,
       commands: null,
       deprecatedEvents: null,
-      hooks: null,
+      hooks: {},
       loadAllPlugins: jest.fn(),
       loadCommand: jest.fn(),
       loadCommands: jest.fn(),


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless-azure-functions/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Runtime support for Linux and Python

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

- Added `kind` to App Service plan and Function app ARM templates
- Added `reserved` and `linuxFxVersion` to Function App template
- Moved `spawn` to Utils class
- Added `CoreToolsService` to handle any CLI invocation of `func`
- Using `CoreToolsService` to package & publish Linux apps
- Only cleaning up built files when not publishing to Linux (see note below)
- Forces Python to run on Linux OS
- Use `/` instead of OS-specific path separator for `function.json` file (works for both windows and linux)
- Cleaning up generated python files in package service
- Fixed typo in name `uploadZippedArfifactToFunctionApp`

*Important*: Because core tools does not currently support publishing an existing package, any Linux applications will not clean built files. Also, because `func azure` (used in publishing) invokes the Azure CLI, I have not been able to get it to run properly as a child process. This will currently give the user the exact command to both publish their function app and then clean up the generated files.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

Specify the `linux` os in your `serverless.yml` like:

```yaml
provider:
    os: linux
```

and run `sls deploy`.

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

_**Note: Run `npm run test:ci` to run all validation checks on proposed changes**_

- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [x] Write documentation
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES  
**_Is it a breaking change?:_** NO
