### PR TITLE
ci: Automatically move new issues to "To triage" column

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,13 @@
+name: "Add new issues to 'To triage' column"
+on:
+  issues:
+    types: [opened]
+jobs:
+  Add_New_Issue_To_Project:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: konradpabjan/actions-add-new-issue-to-column@v1.1
+      with:
+        action-token: "${{ secrets.ACCESS_TOKEN }}"
+        project-url: "https://github.com/serverless/serverless-azure-functions/projects/1"
+        column-name: "To triage"


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless-azure-functions/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Add a new GitHub workflow file to move newly opened issues to `To triage` column in Roadmap project

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
