### PR TITLE
feat: Allow additional arguments to spawned start process

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,16 @@ $ sls offline build
 To clean up files generated from the build, run:
 
 ```bash
-sls offline cleanup
+$ sls offline cleanup
 ```
+
+To pass additional arguments to the spawned `func host start` process, add them as the option `spawnargs` (shortcut `a`). Example:
+
+```bash
+$ sls offline -a "--cors *"
+```
+
+This works for `sls offline` or `sls offline start`
 
 ### Deploy Your Function App
 

--- a/src/plugins/offline/azureOfflinePlugin.ts
+++ b/src/plugins/offline/azureOfflinePlugin.ts
@@ -31,6 +31,10 @@ export class AzureOfflinePlugin extends AzureBasePlugin {
               nocleanup: {
                 usage: "Do not clean up offline files after finishing process",
                 shortcut: "n",
+              },
+              spawnargs: {
+                usage: "Arguments to add to spawned 'func host start' process",
+                shortcut: "a"
               }
             }
           },
@@ -51,6 +55,10 @@ export class AzureOfflinePlugin extends AzureBasePlugin {
           nocleanup: {
             usage: "Do not clean up offline files after finishing process",
             shortcut: "n",
+          },
+          spawnargs: {
+            usage: "Arguments to add to spawned 'func host start' process",
+            shortcut: "a"
           }
         }
       }

--- a/src/services/coreToolsService.ts
+++ b/src/services/coreToolsService.ts
@@ -3,11 +3,12 @@ import { Utils } from "../shared/utils"
 import configConstants from "../config";
 
 export class CoreToolsService {
-  public static async start(serverless: Serverless, onFinish: () => void) {
+  public static async start(serverless: Serverless, onFinish: () => void, additionalArgs?: string[]) {
+    const defaultArgs = configConstants.func.start;
     await Utils.spawn({
       serverless: serverless,
       command: configConstants.func.command,
-      commandArgs: configConstants.func.start,
+      commandArgs: (additionalArgs) ? defaultArgs.concat(additionalArgs) : defaultArgs,
       onSigInt: onFinish
     });
   }

--- a/src/services/offlineService.test.ts
+++ b/src/services/offlineService.test.ts
@@ -212,6 +212,25 @@ describe("Offline Service", () => {
     expect(rmdirCalls[1][0]).toBe("goodbye");
   });
 
+  it("adds additional arguments to spawned process if passed through Serverless args", async () => {
+    Object.defineProperty(process, "platform", {
+      value: "darwin",
+      writable: true,
+    });
+
+    const sls = MockFactory.createTestServerless();
+
+    const service = createService(sls, { "spawnargs": "--cors *"});
+
+    await service.start();
+
+    const calls = mySpawn.calls;
+    expect(calls).toHaveLength(1);
+    const call = calls[0];
+    expect(call.command).toEqual(path.join("node_modules", ".bin", "func"));
+    expect(call.args).toEqual(["host", "start", "--cors", "*"]);
+  });
+
   it("does not clean up after offline call if specified in options", async () => {
 
     Object.defineProperty(process, "platform", {

--- a/src/services/offlineService.ts
+++ b/src/services/offlineService.ts
@@ -48,6 +48,7 @@ export class OfflineService extends BaseService {
    * Spawn `func host start` from core func tools
    */
   public async start() {
+    const args: string = this.getOption("spawnargs");
     await CoreToolsService.start(this.serverless, async () => {
       try {
         if (this.getOption("nocleanup")) {
@@ -61,6 +62,6 @@ export class OfflineService extends BaseService {
       } finally {
         process.exit();
       }
-    });
+    }, (args) ? args.split(" ") : undefined);
   }
 }


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless-azure-functions/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Allow users to pass additional arguments to spawned `func host start` process when running `sls offline`

Closes #365 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Created new option `spawnargs` (shortcut `a`) that takes a whitespace separated string containing additional arguments for new process.

*IMPORTANT* - PR is targeting linux & python support branch because of the significant changes to the way we use core tools within the plugin. That branch has a more forward facing approach to generalizing the use of `azure-functions-core-tools` and made more sense to branch off of it for this issue.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

Run 

```
sls offline -a "--cors *"
```
Rather than `func host start` being spawned, `func host start --cors *` is spawned.

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

_**Note: Run `npm run test:ci` to run all validation checks on proposed changes**_

- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [x] Write documentation
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
