### PR TITLE
feat: Prompt user for confirmation to remove resource group

### DIFF
--- a/src/plugins/remove/azureRemovePlugin.test.ts
+++ b/src/plugins/remove/azureRemovePlugin.test.ts
@@ -1,26 +1,62 @@
 import { MockFactory } from "../../test/mockFactory";
 import { invokeHook } from "../../test/utils";
 import { AzureRemovePlugin } from "./azureRemovePlugin";
+import { Utils } from "../../shared/utils";
 
 jest.mock("../../services/resourceService");
 import { ResourceService } from "../../services/resourceService";
 
 describe("Remove Plugin", () => {
-  it("calls remove hook", async () => {
-    const deleteDeployment = jest.fn();
-    const deleteResourceGroup = jest.fn();
 
-    ResourceService.prototype.deleteDeployment = deleteDeployment;
-    ResourceService.prototype.deleteResourceGroup = deleteResourceGroup;
+  const resourceGroupName = "resource-group"
 
+  beforeEach(() => {
+    ResourceService.prototype.deleteDeployment = jest.fn();
+    ResourceService.prototype.deleteResourceGroup = jest.fn();
+    ResourceService.prototype.getResourceGroupName = jest.fn(() => resourceGroupName);
+    ResourceService.prototype.getResourceGroup = jest.fn(() => Promise.resolve(resourceGroupName)) as any;
+    Utils.waitForUserInput = jest.fn(() => Promise.resolve(resourceGroupName));
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("deletes resource group", async () => {
     const sls = MockFactory.createTestServerless();
     const options = MockFactory.createTestServerlessOptions();
     const plugin = new AzureRemovePlugin(sls, options);
 
     await invokeHook(plugin, "remove:remove");
 
-    expect(deleteDeployment).toBeCalled();
-    expect(deleteResourceGroup).toBeCalled();
-    expect(sls.cli.log).toBeCalledWith("Service successfully removed");
+    expect(ResourceService.prototype.deleteDeployment).toBeCalled();
+    expect(ResourceService.prototype.deleteResourceGroup).toBeCalled();
+  });
+
+  it("does not delete resource group if it doesn't exist in Azure", async () => {
+    ResourceService.prototype.getResourceGroup = jest.fn(() => undefined);
+    
+    const sls = MockFactory.createTestServerless();
+    const options = MockFactory.createTestServerlessOptions();
+    const plugin = new AzureRemovePlugin(sls, options);
+
+    await invokeHook(plugin, "remove:remove");
+
+    expect(ResourceService.prototype.deleteDeployment).not.toBeCalled();
+    expect(ResourceService.prototype.deleteResourceGroup).not.toBeCalled();
+    expect(sls.cli.log).lastCalledWith(`Resource group "${resourceGroupName}" does not exist in your Azure subscription`);
+  });
+
+  it("does not delete resource group if user input does not match resource group", async () => {
+    Utils.waitForUserInput = jest.fn(() => Promise.resolve("not-my-resource-group"));
+    
+    const sls = MockFactory.createTestServerless();
+    const options = MockFactory.createTestServerlessOptions();
+    const plugin = new AzureRemovePlugin(sls, options);
+
+    await invokeHook(plugin, "remove:remove");
+
+    expect(ResourceService.prototype.deleteDeployment).not.toBeCalled();
+    expect(ResourceService.prototype.deleteResourceGroup).not.toBeCalled();
   });
 });

--- a/src/plugins/remove/azureRemovePlugin.ts
+++ b/src/plugins/remove/azureRemovePlugin.ts
@@ -48,7 +48,8 @@ export class AzureRemovePlugin extends AzureBasePlugin {
       this.log(`Resource group "${rgName}" does not exist in your Azure subscription`)
       return;
     }
-    this.log(`This command will delete your entire resource group (${resourceService.getResourceGroupName()}). ` +
+    this.log(`This command will delete your ENTIRE resource group (${resourceService.getResourceGroupName()}). ` +
+      "and ALL the Azure resources that it contains " +
       "Are you sure you want to proceed? If so, enter the full name of the resource group :");
     const input = await Utils.waitForUserInput();
     if (input === resourceService.getResourceGroupName()) {

--- a/src/plugins/remove/azureRemovePlugin.ts
+++ b/src/plugins/remove/azureRemovePlugin.ts
@@ -1,6 +1,7 @@
 import Serverless from "serverless";
 import { ResourceService } from "../../services/resourceService";
 import { AzureBasePlugin } from "../azureBasePlugin";
+import { Utils } from "../../shared/utils";
 
 export class AzureRemovePlugin extends AzureBasePlugin {
 
@@ -40,10 +41,25 @@ export class AzureRemovePlugin extends AzureBasePlugin {
   }
 
   private async remove() {
-    const resourceClient = new ResourceService(this.serverless, this.options);
-    await resourceClient.deleteDeployment();
-    await resourceClient.deleteResourceGroup();
-
-    this.log("Service successfully removed");
+    const resourceService = new ResourceService(this.serverless, this.options);
+    const rg = await resourceService.getResourceGroup();
+    const rgName = resourceService.getResourceGroupName();
+    if (!rg) {
+      this.log(`Resource group "${rgName}" does not exist in your Azure subscription`)
+      return;
+    }
+    this.log(`This command will delete your entire resource group (${resourceService.getResourceGroupName()}). ` +
+      "Are you sure you want to proceed? If so, enter the full name of the resource group :");
+    const input = await Utils.waitForUserInput();
+    if (input === resourceService.getResourceGroupName()) {
+      this.log("Deleting resource group");
+      await resourceService.deleteDeployment();
+      await resourceService.deleteResourceGroup();
+      this.log("Service successfully removed");
+    }
+    else {
+      this.log("Will not remove resource group.");
+      return;
+    }
   }
 }

--- a/src/services/resourceService.test.ts
+++ b/src/services/resourceService.test.ts
@@ -245,4 +245,12 @@ describe("Resource Service", () => {
     const expected = deployments[deployments.length - 1];
     expect(deployment).toEqual(expected);
   });
+
+  it("gets resource group name", () => {
+    const resourceGroup = "resource-group";
+    const sls = MockFactory.createTestServerless();
+    sls.service.provider["resourceGroup"] = resourceGroup;
+    const service = new ResourceService(sls, {} as any);
+    expect(service.getResourceGroupName()).toEqual(resourceGroup);
+  });
 });

--- a/src/services/resourceService.ts
+++ b/src/services/resourceService.ts
@@ -16,6 +16,13 @@ export class ResourceService extends BaseService {
   }
 
   /**
+   * Name of configured resource group
+   */
+  public getResourceGroupName(): string {
+    return this.resourceGroup;
+  }
+
+  /**
    * Get all deployments for resource group sorted by timestamp (most recent first)
    */
   public async getDeployments() {

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -3,6 +3,7 @@ import Serverless from "serverless";
 import { ServerlessAzureFunctionConfig, ServerlessAzureConfig } from "../models/serverless";
 import { BindingUtils } from "./bindings";
 import { constants } from "./constants";
+import { createInterface } from "readline"
 
 export interface FunctionMetadata {
   entryPoint: any;
@@ -186,6 +187,23 @@ export class Utils {
   public static wait(time: number = 1000) {
     return new Promise((resolve) => {
       setTimeout(resolve, time);
+    });
+  }
+
+  /**
+   * Wait for user input and return it
+   */
+  public static async waitForUserInput(): Promise<string> {
+    const rl = createInterface({
+      input: process.stdin,
+      output: process.stdout,
+    });
+
+    return new Promise((resolve) => {
+      rl.question("", (answer: string) => {
+        rl.close();
+        resolve(answer);
+      });
     });
   }
 }


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless-azure-functions/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Requires user to enter resource group name as confirmation for group removal

Closes #380 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

- Added utility function to wait for user input
- Check user input against configured resource group name
- Delete if results match

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

- Try to remove a non-deployed project
- Run `sls remove` and then just type `Enter` (empty string shouldn't match), removal won't happen
- Run `sls remove` and then type exact resource group name and removal will happen

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

_**Note: Run `npm run test:ci` to run all validation checks on proposed changes**_

- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [x] Write documentation
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
