### PR TITLE
perf: Cache provider config on initialization

### DIFF
--- a/src/services/configService.ts
+++ b/src/services/configService.ts
@@ -145,6 +145,12 @@ export class ConfigService {
    */
   private initializeConfig(service: Service): ServerlessAzureConfig {
     const config: ServerlessAzureConfig = service as any;
+    const providerConfig = Utils.get(this.serverless.variables, constants.variableKeys.providerConfig);
+    if (providerConfig) {
+      config.provider = providerConfig;
+      return config;
+    }
+    this.serverless.cli.log("Initializing provider configuration...");
     this.setDefaultValues(config);
 
     const {
@@ -184,7 +190,7 @@ export class ConfigService {
       this.getOption("resourceGroup", config.provider.resourceGroup)
     ) || AzureNamingService.getResourceName(options);
 
-    // Get property from `runFromBlobUrl` for backwards compatability
+    // Get property from `runFromBlobUrl` for backwards compatibility
     if (deployment && deployment.external === undefined && deployment["runFromBlobUrl"] !== undefined) {
       deployment.external = deployment["runFromBlobUrl"];
     }
@@ -194,8 +200,9 @@ export class ConfigService {
       ...deployment
     }
 
-    config.provider.functionRuntime = this.getRuntime(runtime)
+    config.provider.functionRuntime = this.getRuntime(runtime);
 
+    this.serverless.variables[constants.variableKeys.providerConfig] = config.provider;
     return config;
   }
 

--- a/src/services/functionAppService.test.ts
+++ b/src/services/functionAppService.test.ts
@@ -157,7 +157,8 @@ describe("Function App Service", () => {
     const logCalls = (sls.cli.log as any).mock.calls as any[];
     for (let i = 0; i < functionNames.length; i++) {
       const functionName = functionNames[i];
-      expect(logCalls[i + 1][0]).toEqual(`-> Deleting function: ${functionName}`);
+      const call = logCalls.find((c) => c[0] === `-> Deleting function: ${functionName}`);
+      expect(call).toBeTruthy();
     }
   });
 

--- a/src/services/rollbackService.test.ts
+++ b/src/services/rollbackService.test.ts
@@ -88,7 +88,7 @@ describe("Rollback Service", () => {
     const service = createService(sls, options);
     await service.rollback();
     const calls = (sls.cli.log as any).mock.calls;
-    expect(calls[0][0]).toEqual(`Couldn't find deployment with timestamp: ${timestamp}`);
+    expect(calls[1][0]).toEqual(`Couldn't find deployment with timestamp: ${timestamp}`);
   });
 
   it("should deploy blob package directly to function app", async () => {

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -22,7 +22,7 @@ export const constants = {
   xAzureSettings: "x-azure-settings",
   entryPoint: "entryPoint",
   variableKeys: {
-    config: "serverlessAzureConfig",
+    providerConfig: "serverlessAzureProviderConfig",
     subscriptionId: "subscriptionId",
     tenantId: "tenantId",
     appId: "appId",


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless-azure-functions/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Cache provider configuration in `serverless.variables` in `ConfigService` initialization

Closes #370 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

- Check `serverless.variables` for cached config
- If it's not there, initialize the config and store it in `serverless.variables`

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

- See unit test.
- There is a log statement when provider config is initialized. This will not print if using cached config

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

_**Note: Run `npm run test:ci` to run all validation checks on proposed changes**_

- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [x] Write documentation
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
