### PR TITLE
feat: Support for specifying premium scaling options in serverless yaml

### DIFF
--- a/src/armTemplates/resources/appServicePlan.test.ts
+++ b/src/armTemplates/resources/appServicePlan.test.ts
@@ -52,4 +52,96 @@ describe("App Service Plan Resource", () => {
 
     expect(AppServicePlanResource.getResourceName(config)).toEqual(appServicePlanName);
   });
+
+  it("generates correct default parameters", () => {
+    const config: ServerlessAzureConfig = {
+      provider: {
+        name: "azure",
+        prefix,
+        region,
+        stage,
+        resourceGroup: resourceGroupName,
+        runtime: "nodejs10.x",
+      },
+      plugins: [],
+      functions: {},
+      service: "myapp",
+    };
+
+    const appServicePlanResource = new AppServicePlanResource();
+    const params = appServicePlanResource.getParameters(config);
+
+    expect(Object.keys(params)).toHaveLength(7);
+    expect(params.appServicePlanName.value).toEqual(AppServicePlanResource.getResourceName(config));
+    expect(params.appServicePlanSkuName.value).toBeUndefined();
+    expect(params.appServicePlanSkuTier.value).toBeUndefined();
+    expect(params.appServicePlanWorkerSizeId.value).toBeUndefined();
+    expect(params.appServicePlanMinWorkerCount.value).toBeUndefined();
+    expect(params.appServicePlanMaxWorkerCount.value).toBeUndefined();
+    expect(params.appServicePlanHostingEnvironment.value).toBeUndefined();
+  });
+
+  it("generates correct specified parameters", () => {
+    const config: ServerlessAzureConfig = {
+      provider: {
+        name: "azure",
+        prefix,
+        region,
+        stage,
+        resourceGroup: resourceGroupName,
+        runtime: "nodejs10.x",
+        appServicePlan: {
+          name: "customAppServicePlanName",
+          hostingEnvironment: "customHostingEnvironment",
+          sku: {
+            name: "EP2",
+            tier: "specialTier"
+          },
+          scale: {
+            minWorkerCount: 3,
+            maxWorkerCount: 20,
+            workerSizeId: "4"
+          }
+        }
+      },
+      plugins: [],
+      functions: {},
+      service: "myapp",
+    };
+
+    const appServicePlanResource = new AppServicePlanResource();
+    const params = appServicePlanResource.getParameters(config);
+
+    expect(Object.keys(params)).toHaveLength(7);
+    expect(params.appServicePlanName.value).toEqual(config.provider.appServicePlan.name);
+    expect(params.appServicePlanSkuName.value).toEqual(config.provider.appServicePlan.sku.name);
+    expect(params.appServicePlanSkuTier.value).toEqual(config.provider.appServicePlan.sku.tier);
+    expect(params.appServicePlanWorkerSizeId.value).toEqual(config.provider.appServicePlan.scale.workerSizeId);
+    expect(params.appServicePlanMinWorkerCount.value).toEqual(config.provider.appServicePlan.scale.minWorkerCount);
+    expect(params.appServicePlanMaxWorkerCount.value).toEqual(config.provider.appServicePlan.scale.maxWorkerCount);
+    expect(params.appServicePlanHostingEnvironment.value).toEqual(config.provider.appServicePlan.hostingEnvironment);
+  });
+
+  it("generates the expected template", () => {
+    const appServicePlanResource = new AppServicePlanResource();
+    const template = appServicePlanResource.getTemplate();
+    const appServicePlan = template.resources[0];
+
+    expect(appServicePlan).toMatchObject({
+      name: "[parameters('appServicePlanName')]",
+      type: "Microsoft.Web/serverfarms",
+      location: "[parameters('location')]",
+      properties: {
+        name: "[parameters('appServicePlanName')]",
+        workerSizeId: "[parameters('appServicePlanWorkerSizeId')]",
+        numberOfWorkers: "[parameters('appServicePlanMinWorkerCount')]",
+        maximumElasticWorkerCount: "[parameters('appServicePlanMaxWorkerCount')]",
+        hostingEnvironment: "[parameters('appServicePlanHostingEnvironment')]",
+      },
+      sku: {
+        name: "[parameters('appServicePlanSkuName')]",
+        tier: "[parameters('appServicePlanSkuTier')]"
+      }
+    });
+  });
 });

--- a/src/armTemplates/resources/appServicePlan.ts
+++ b/src/armTemplates/resources/appServicePlan.ts
@@ -6,6 +6,10 @@ interface AppServicePlanParams extends DefaultArmParams {
   appServicePlanName: ArmParameter;
   appServicePlanSkuName: ArmParameter;
   appServicePlanSkuTier: ArmParameter;
+  appServicePlanWorkerSizeId: ArmParameter;
+  appServicePlanMinWorkerCount: ArmParameter;
+  appServicePlanMaxWorkerCount: ArmParameter;
+  appServicePlanHostingEnvironment: ArmParameter;
 }
 
 export class AppServicePlanResource implements ArmResourceTemplateGenerator {
@@ -35,6 +39,22 @@ export class AppServicePlanResource implements ArmResourceTemplateGenerator {
       appServicePlanSkuTier: {
         defaultValue: "ElasticPremium",
         type: ArmParamType.String
+      },
+      appServicePlanWorkerSizeId: {
+        defaultValue: "3",
+        type: ArmParamType.String
+      },
+      appServicePlanMinWorkerCount: {
+        defaultValue: 1,
+        type: ArmParamType.Int,
+      },
+      appServicePlanMaxWorkerCount: {
+        defaultValue: 10,
+        type: ArmParamType.Int
+      },
+      appServicePlanHostingEnvironment: {
+        defaultValue: "",
+        type: ArmParamType.String
       }
     };
 
@@ -51,10 +71,10 @@ export class AppServicePlanResource implements ArmResourceTemplateGenerator {
           "location": "[parameters('location')]",
           "properties": {
             "name": "[parameters('appServicePlanName')]",
-            "workerSizeId": "3",
-            "numberOfWorkers": "1",
-            "maximumElasticWorkerCount": "10",
-            "hostingEnvironment": ""
+            "workerSizeId": "[parameters('appServicePlanWorkerSizeId')]",
+            "numberOfWorkers": "[parameters('appServicePlanMinWorkerCount')]",
+            "maximumElasticWorkerCount": "[parameters('appServicePlanMaxWorkerCount')]",
+            "hostingEnvironment": "[parameters('appServicePlanHostingEnvironment')]"
           },
           "sku": {
             "name": "[parameters('appServicePlanSkuName')]",
@@ -68,7 +88,8 @@ export class AppServicePlanResource implements ArmResourceTemplateGenerator {
   public getParameters(config: ServerlessAzureConfig): ArmParameters {
     const resourceConfig: ResourceConfig = {
       sku: {},
-      ...config.provider.storageAccount,
+      scale: {},
+      ...config.provider.appServicePlan,
     };
 
     const params: AppServicePlanParams = {
@@ -80,9 +101,21 @@ export class AppServicePlanResource implements ArmResourceTemplateGenerator {
       },
       appServicePlanSkuTier: {
         value: resourceConfig.sku.tier,
+      },
+      appServicePlanWorkerSizeId: {
+        value: resourceConfig.scale.workerSizeId
+      },
+      appServicePlanMinWorkerCount: {
+        value: resourceConfig.scale.minWorkerCount
+      },
+      appServicePlanMaxWorkerCount: {
+        value: resourceConfig.scale.maxWorkerCount
+      },
+      appServicePlanHostingEnvironment: {
+        value: resourceConfig.hostingEnvironment
       }
     }
 
-    return params as unknown as ArmParameters;
+    return params;
   }
 }

--- a/src/models/armTemplates.ts
+++ b/src/models/armTemplates.ts
@@ -54,7 +54,7 @@ export interface ArmParameter {
   defaultValue?: string | number;
 }
 
-export interface DefaultArmParams {
+export interface DefaultArmParams extends ArmParameters {
   location?: ArmParameter;
 }
 

--- a/src/models/serverless.ts
+++ b/src/models/serverless.ts
@@ -8,7 +8,7 @@ export interface ArmTemplateConfig {
 }
 
 export interface ResourceConfig {
-  name: string;
+  name?: string;
   sku?: {
     name?: string;
     tier?: string;
@@ -49,7 +49,7 @@ export interface ServerlessAzureProvider {
   apim?: ApiManagementConfig;
   functionApp?: FunctionAppConfig;
   appInsights?: ResourceConfig;
-  appServicePlan?: ResourceConfig;
+  appServicePlan?: AppServicePlanConfig;
   storageAccount?: ResourceConfig;
   hostingEnvironment?: ResourceConfig;
   virtualNetwork?: ResourceConfig;
@@ -82,6 +82,15 @@ export interface AzureKeyVaultConfig {
   name: string;
   /** The name of the azure resource group with the key vault */
   resourceGroup: string;
+}
+
+export interface AppServicePlanConfig extends ResourceConfig {
+  scale?: {
+    minWorkerCount?: number;
+    maxWorkerCount?: number;
+    workerSizeId?: string;
+  };
+  hostingEnvironment?: string;
 }
 
 /**
@@ -144,7 +153,7 @@ export interface ServerlessAzureConfig {
   provider: ServerlessAzureProvider;
   plugins: string[];
   functions: any;
-  package: {
+  package?: {
     individually: boolean;
     artifactDirectoryName: string;
     artifact: string;


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless-azure-functions/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Adds support to specify your scaling parameters for the app service plan hosting a premium functions app.
```yaml
provider:
  name: azure
  appServicePlan:
    sku:
      name: EP3 # Default is EP1
    scale:
      minWorkerCount: 3 # Default is 1
      maxWorkerCount: 10 # Default is 10
```
<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
Created new ARM template parameters that are auto configured via serverless yaml
<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:
Run unit tests with `npm run test`
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

_**Note: Run `npm run test:ci` to run all validation checks on proposed changes**_

- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [ ] Write documentation
- [ ] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
