### PR TITLE
Fix: Use correct displayName for cosmosDBTrigger

### DIFF
--- a/src/shared/bindings.json
+++ b/src/shared/bindings.json
@@ -1305,7 +1305,7 @@
     },
     {
       "type": "cosmosDBTrigger",
-      "displayName": "$cosmosDBIn_displayName",
+      "displayName": "$cosmosDBTriggerIn_displayName",
       "direction": "trigger",
       "enabledInTryMode": false,
       "documentation": "$content=Documentation\\cosmosDBTrigger.md",


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless-azure-functions/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:
Used correct displayName for cosmosDBTrigger to fix getting "Binding not supported" error.

Closes #389

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->
Changed the displayName from $cosmosDBIn_displayName to $cosmosDBTriggerIn_displayName

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.-->

Try to deploy the following function before & after the change:
```
  cosmosChangeFeed:
    handler: cosmosChangeFeed.handler
    events:
      - cosmosDB:
        x-azure-settings:
          direction: in
          name: documents
          databaseName: databaseName
          collectionName: containerName
          leaseCollectionName: leases
          connectionStringSetting: COSMOS_DB_CONNECTION
          createLeaseCollectionIfNotExists: true
```

<!--
## Todos:

_**Note: Run `npm run test:ci` to run all validation checks on proposed changes**_

- [ ] Ensure there are no lint errors.  
       **Validate via `npm run lint`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [ ] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [ ] Write documentation
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
-->