### PR TITLE
fix: Don't try to clean up non-existent directories

### DIFF
--- a/src/services/packageService.test.ts
+++ b/src/services/packageService.test.ts
@@ -63,6 +63,21 @@ describe("Package Service", () => {
     rmdirSpy.mockRestore();
   });
 
+  it("does not clean up function folder if non-existent", async () => {
+    mockFs({});
+
+    const unlinkSpy = jest.spyOn(fs, "unlinkSync");
+    const rmdirSpy = jest.spyOn(fs, "rmdirSync");
+
+    packageService.cleanUp();
+
+    expect(unlinkSpy).not.toBeCalled();
+    expect(rmdirSpy).not.toBeCalled();
+
+    unlinkSpy.mockRestore();
+    rmdirSpy.mockRestore();
+  });
+
   it("cleans up function.json but does not delete function folder", async () => {
     const fsConfig = {};
 

--- a/src/services/packageService.ts
+++ b/src/services/packageService.ts
@@ -76,7 +76,11 @@ export class PackageService extends BaseService {
         fs.unlinkSync(filePath);
       }
 
-      // Delete function folder if empty
+      // Delete function folder if exists and empty
+      if (!fs.existsSync(functionName)) {
+        return;
+      }
+
       const items = fs.readdirSync(functionName);
       if (items.length === 0) {
         fs.rmdirSync(functionName);


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless-azure-functions/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Check to see if directory exists before trying to delete it

Closes #349 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Added one check to see if directory exists before reading/deleting it

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

- Create a new project
- Run `sls offline cleanup`

This would have failed before, as it would try to read and then delete directories named after your functions. This check prevents that from happening

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

_**Note: Run `npm run test:ci` to run all validation checks on proposed changes**_

- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [x] Write documentation
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
