### PR TITLE
feat: Eliminate need for 'x-azure-settings' config

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -53,11 +53,10 @@ functions:
     events:
       # Http Triggered function
       - http: true
-        x-azure-settings:
-          # Allows GET method
-          methods:
-            - GET
-          authLevel: anonymous # can also be `function` or `admin`
+        # Allows GET method
+        methods:
+          - GET
+        authLevel: anonymous # can also be `function` or `admin`
 ```
 
 ## Full Example Config
@@ -142,66 +141,58 @@ functions:
     handler: src/handlers/hello.sayHello
     events:
       - http: true
-        x-azure-settings:
-          methods:
-            - GET
-          authLevel: anonymous # can also be `function` or `admin`
+        methods:
+          - GET
+        authLevel: anonymous # can also be `function` or `admin`
 
   goodbye:
     handler: src/handlers/goodbye.sayGoodbye
     events:
       - http: true
-        x-azure-settings:
-          methods:
-            - GET
-          authLevel: anonymous
+        methods:
+          - GET
+        authLevel: anonymous
   # The following are a few examples of other events you can configure:
   # storageBlob:
   #   handler: src/handlers/storageBlob.printMessage
   #   events:
   #     - blob:
-  #       x-azure-settings:
-  #         name: blob # Specifies which name is available on `context`
-  #         path: blob-sample/{blobName}
-  #         connection: AzureWebJobsStorage # App Setting/environment variable which contains Storage Account Connection String
+#         name: blob # Specifies which name is available on `context`
+#         path: blob-sample/{blobName}
+#         connection: AzureWebJobsStorage # App Setting/environment variable which contains Storage Account Connection String
   # storageQueue:
   #   handler: src/handlers/storageQueue.printMessage
   #   events:
   #     - queue: queue-sample
-  #       x-azure-settings:
-  #         name: message # Specifies which naem is available on `context`
-  #         connection: AzureWebJobsStorage
+#         name: message # Specifies which naem is available on `context`
+#         connection: AzureWebJobsStorage
   # timer:
   #   handler: src/handlers/timer.printMessage
   #   events:
   #     - timer:
-  #       x-azure-settings:
-  #         schedule: '*/10 * * * * *'
+#         schedule: '*/10 * * * * *'
   # eventhub:
   #   handler: src/handlers/eventHub.printMessage
   #   events:
   #     - eventHub:
-  #       x-azure-settings:
-  #         name: eventHubMessages # Specifies which name it's available on `context`
-  #         eventHubName: sample-hub # Specifies the Name of the Event Hub
-  #         consumerGroup: $Default # Specifies the consumerGroup to listen with
-  #         connection: EVENT_HUBS_CONNECTION # App Setting/environment variable which contains Event Hubs Namespace Connection String
+#         name: eventHubMessages # Specifies which name it's available on `context`
+#         eventHubName: sample-hub # Specifies the Name of the Event Hub
+#         consumerGroup: $Default # Specifies the consumerGroup to listen with
+#         connection: EVENT_HUBS_CONNECTION # App Setting/environment variable which contains Event Hubs Namespace Connection String
   # serviceBusQueue:
   #   handler: src/handlers/serviceBusQueue.printMessage
   #   events:
   #     - serviceBus:
-  #       x-azure-settings:
-  #         name: message # Specifies which name is available on `context`
-  #         queueName: sample-queue # Name of the service bus queue to consume
-  #         connection: SERVICE_BUS_CONNECTION # App Setting/environment variable variable which contains Service Bus Namespace Connection String
+#         name: message # Specifies which name is available on `context`
+#         queueName: sample-queue # Name of the service bus queue to consume
+#         connection: SERVICE_BUS_CONNECTION # App Setting/environment variable variable which contains Service Bus Namespace Connection String
   # serviceBusTopic:
   #   handler: src/handlers/serviceBusTopic.printMessage
   #   events:
   #     - serviceBus:
-  #       x-azure-settings:
-  #         name: message # Specifies which name it's available on `context`
-  #         topicName: sample-topic # Name of the service bus topic to consume
-  #         subscriptionName: sample-subscription # Name of the topic subscription to retrieve from
-  #         connection: SERVICE_BUS_CONNECTION # App Setting/environment variable variable which contains Service Bus Namespace Connection String
+#         name: message # Specifies which name it's available on `context`
+#         topicName: sample-topic # Name of the service bus topic to consume
+#         subscriptionName: sample-subscription # Name of the topic subscription to retrieve from
+#         connection: SERVICE_BUS_CONNECTION # App Setting/environment variable variable which contains Service Bus Namespace Connection String
 
 ```

--- a/docs/examples/apim.md
+++ b/docs/examples/apim.md
@@ -29,10 +29,9 @@ functions:
     handler: src/handlers/hello.handler
     events:
       - http: true
-        x-azure-settings:
-          methods:
-            - GET
-          authLevel : function
+        methods:
+          - GET
+        authLevel : function
 ```
 
 ## Full Configuration
@@ -181,10 +180,9 @@ functions:
           displayName: GetProducts
     events:
       - http: true
-        x-azure-settings:
-          methods:
-            - GET
-          authLevel : function
+        methods:
+          - GET
+        authLevel : function
   getCategories:
     handler: src/handlers/getCategories.handler
 
@@ -203,8 +201,7 @@ functions:
           displayName: GetCategories
     events:
       - http: true
-        x-azure-settings:
-          methods:
-            - GET
-          authLevel : function
+        methods:
+          - GET
+        authLevel : function
 ```

--- a/src/models/serverless.ts
+++ b/src/models/serverless.ts
@@ -156,7 +156,13 @@ export interface ServerlessAzureFunctionConfig {
 
 export interface ServerlessAzureFunctionBindingConfig {
   http?: boolean;
-  "x-azure-settings": ServerlessExtraAzureSettingsConfig;
+  direction?: string;
+  route?: string;
+  name?: string;
+  authLevel?: string;
+  methods?: string[];
+  /** Maintained for backwards compatibility */
+  "x-azure-settings"?: ServerlessExtraAzureSettingsConfig;
 }
 
 export interface ServerlessExtraAzureSettingsConfig {

--- a/src/plugins/func/azureFuncPlugin.test.ts
+++ b/src/plugins/func/azureFuncPlugin.test.ts
@@ -67,7 +67,7 @@ describe("Azure Func Plugin", () => {
       const functionName = "myFunction";
       options["name"] = functionName;
       const expectedFunctionsYml = MockFactory.createTestSlsFunctionConfig(false);
-      expectedFunctionsYml[functionName] = MockFactory.createTestFunctionMetadata(functionName, false);
+      expectedFunctionsYml[functionName] = MockFactory.createTestFunctionMetadata(functionName);
 
       const plugin = new AzureFuncPlugin(sls, options);
 

--- a/src/plugins/func/azureFuncPlugin.test.ts
+++ b/src/plugins/func/azureFuncPlugin.test.ts
@@ -62,11 +62,12 @@ describe("Azure Func Plugin", () => {
 
     it("creates function handler and updates serverless.yml", async () => {
       const sls = MockFactory.createTestServerless();
+      MockFactory.updateService(sls, MockFactory.createTestSlsFunctionConfig(false))
       const options = MockFactory.createTestServerlessOptions();
       const functionName = "myFunction";
       options["name"] = functionName;
-      const expectedFunctionsYml = MockFactory.createTestSlsFunctionConfig();
-      expectedFunctionsYml[functionName] = MockFactory.createTestFunctionMetadata(functionName);
+      const expectedFunctionsYml = MockFactory.createTestSlsFunctionConfig(false);
+      expectedFunctionsYml[functionName] = MockFactory.createTestFunctionMetadata(functionName, false);
 
       const plugin = new AzureFuncPlugin(sls, options);
 

--- a/src/services/apimService.test.ts
+++ b/src/services/apimService.test.ts
@@ -1,29 +1,21 @@
-import Serverless from "serverless";
-import _ from "lodash";
-import { MockFactory } from "../test/mockFactory";
-import { ApimService } from "./apimService";
-import { interpolateJson } from "../test/utils";
+import { Api, ApiManagementService, ApiOperation, ApiOperationPolicy, ApiPolicy, Backend, Property } from "@azure/arm-apimanagement";
+import { ApiContract, ApiCreateOrUpdateResponse, ApiGetResponse, ApiManagementServiceGetResponse, ApiManagementServiceResource, ApiOperationCreateOrUpdateResponse, ApiPolicyCreateOrUpdateResponse, ApiPolicyGetResponse, BackendContract, BackendCreateOrUpdateResponse, OperationContract, PolicyContract, PropertyContract, PropertyCreateOrUpdateResponse } from "@azure/arm-apimanagement/esm/models";
 import axios from "axios";
-import { Api, Backend, Property, ApiOperation, ApiOperationPolicy, ApiManagementService, ApiPolicy } from "@azure/arm-apimanagement";
-import apimGetService404 from "../test/responses/apim-get-service-404.json";
-import apimGetService200 from "../test/responses/apim-get-service-200.json";
+import _ from "lodash";
+import Serverless from "serverless";
+import { Runtime } from "../config/runtime";
+import { ApiCheckHeaderPolicy, ApiIpFilterPolicy, ApiManagementConfig } from "../models/apiManagement";
+import { constants } from "../shared/constants";
+import { MockFactory } from "../test/mockFactory";
 import apimGetApi200 from "../test/responses/apim-get-api-200.json";
 import apimGetApi404 from "../test/responses/apim-get-api-404.json";
-import { FunctionAppService } from "./functionAppService";
-import {
-  PropertyContract, BackendContract, BackendCreateOrUpdateResponse,
-  ApiCreateOrUpdateResponse, PropertyCreateOrUpdateResponse, ApiContract,
-  ApiOperationCreateOrUpdateResponse, ApiManagementServiceResource, ApiGetResponse,
-  ApiManagementServiceGetResponse,
-  OperationContract,
-  ApiPolicyCreateOrUpdateResponse,
-  PolicyContract,
-  ApiPolicyGetResponse
-} from "@azure/arm-apimanagement/esm/models";
-import { AzureNamingService } from "./namingService";
-import { ApiManagementConfig, ApiIpFilterPolicy, ApiCheckHeaderPolicy } from "../models/apiManagement";
+import apimGetService200 from "../test/responses/apim-get-service-200.json";
+import apimGetService404 from "../test/responses/apim-get-service-404.json";
+import { interpolateJson } from "../test/utils";
 import { ApimPolicyBuilder } from "./apimPolicyBuilder";
-import { Runtime } from "../config/runtime";
+import { ApimService } from "./apimService";
+import { FunctionAppService } from "./functionAppService";
+import { AzureNamingService } from "./namingService";
 
 describe("APIM Service", () => {
   let apimConfig: ApiManagementConfig;
@@ -602,8 +594,8 @@ describe("APIM Service", () => {
 
     it("uses GET as default HTTP method with inferred APIM operation", async () => {
       const functions = MockFactory.createTestSlsFunctionConfig();
-      functions.hello.events.forEach((event) => delete event["x-azure-settings"].methods);
-      functions.goodbye.events.forEach((event) => delete event["x-azure-settings"].methods);
+      functions.hello.events.forEach((event) => delete event.methods);
+      functions.goodbye.events.forEach((event) => delete event.methods);
       Object.assign(serverless.service, { functions });
 
       let apimResource: ApiManagementServiceResource = {

--- a/src/services/apimService.ts
+++ b/src/services/apimService.ts
@@ -13,6 +13,7 @@ import { Guard } from "../shared/guard";
 import { ApimResource } from "../armTemplates/resources/apim";
 import { ServerlessExtraAzureSettingsConfig } from "../models/serverless";
 import { Utils } from "../shared/utils";
+import { constants } from "../shared/constants";
 
 /**
  * APIM Service handles deployment and integration with Azure API Management
@@ -144,7 +145,7 @@ export class ApimService extends BaseService {
       return;
     }
 
-    const httpConfig: ServerlessExtraAzureSettingsConfig = Utils.get(httpEvent, "x-azure-settings", httpEvent);
+    const httpConfig: ServerlessExtraAzureSettingsConfig = Utils.get(httpEvent, constants.xAzureSettings, httpEvent);
 
     // Default to GET method if not specified
     if (!httpConfig.methods) {

--- a/src/services/apimService.ts
+++ b/src/services/apimService.ts
@@ -12,6 +12,7 @@ import { Site } from "@azure/arm-appservice/esm/models";
 import { Guard } from "../shared/guard";
 import { ApimResource } from "../armTemplates/resources/apim";
 import { ServerlessExtraAzureSettingsConfig } from "../models/serverless";
+import { Utils } from "../shared/utils";
 
 /**
  * APIM Service handles deployment and integration with Azure API Management
@@ -143,7 +144,7 @@ export class ApimService extends BaseService {
       return;
     }
 
-    const httpConfig: ServerlessExtraAzureSettingsConfig = httpEvent["x-azure-settings"];
+    const httpConfig: ServerlessExtraAzureSettingsConfig = Utils.get(httpEvent, "x-azure-settings", httpEvent);
 
     // Default to GET method if not specified
     if (!httpConfig.methods) {

--- a/src/services/funcService.test.ts
+++ b/src/services/funcService.test.ts
@@ -62,7 +62,7 @@ describe("Azure Func Service", () => {
       const functionName = "myFunction";
       options["name"] = functionName;
       const expectedFunctionsYml = MockFactory.createTestSlsFunctionConfig(false);
-      expectedFunctionsYml[functionName] = MockFactory.createTestFunctionMetadata(functionName, false);
+      expectedFunctionsYml[functionName] = MockFactory.createTestFunctionMetadata(functionName);
 
       const service = createService(sls, options);
       await service.add();

--- a/src/services/funcService.test.ts
+++ b/src/services/funcService.test.ts
@@ -57,11 +57,12 @@ describe("Azure Func Service", () => {
 
     it("creates function handler and updates serverless.yml", async () => {
       const sls = MockFactory.createTestServerless();
+      MockFactory.updateService(sls, MockFactory.createTestSlsFunctionConfig(false))
       const options = MockFactory.createTestServerlessOptions();
       const functionName = "myFunction";
       options["name"] = functionName;
-      const expectedFunctionsYml = MockFactory.createTestSlsFunctionConfig();
-      expectedFunctionsYml[functionName] = MockFactory.createTestFunctionMetadata(functionName);
+      const expectedFunctionsYml = MockFactory.createTestSlsFunctionConfig(false);
+      expectedFunctionsYml[functionName] = MockFactory.createTestFunctionMetadata(functionName, false);
 
       const service = createService(sls, options);
       await service.add();

--- a/src/services/funcService.ts
+++ b/src/services/funcService.ts
@@ -112,16 +112,12 @@ module.exports.handler = async function (context, req) {
     return [
       {
         http: true,
-        "x-azure-settings": {
-          authLevel: "anonymous"
-        }
+        authLevel: "anonymous"
       },
       {
         http: true,
-        "x-azure-settings": {
-          direction: "out",
-          name: "res"
-        }
+        direction: "out",
+        name: "res"
       },
     ]
   }

--- a/src/services/invokeService.ts
+++ b/src/services/invokeService.ts
@@ -68,7 +68,7 @@ export class InvokeService extends BaseService {
 
   private getConfiguredFunctionRoute(functionName: string) {
     try {
-      const { route } = this.config.functions[functionName].events[0]["x-azure-settings"];
+      const { route } = this.config.functions[functionName].events[0];
       return route || functionName
     } catch {
       return functionName;

--- a/src/services/packageService.ts
+++ b/src/services/packageService.ts
@@ -143,7 +143,9 @@ export class PackageService extends BaseService {
     functionJSON.scriptFile = handlerPath;
 
     const functionObject = this.configService.getFunctionConfig()[functionName];
-    const bindingAzureSettings = Utils.getIncomingBindingConfig(functionObject)["x-azure-settings"];
+    const incomingBinding = Utils.getIncomingBindingConfig(functionObject);
+    
+    const bindingAzureSettings = Utils.get(incomingBinding, "x-azure-settings", incomingBinding);
 
     if (bindingAzureSettings.route) {
       // Find incoming binding within functionJSON and set the route

--- a/src/services/packageService.ts
+++ b/src/services/packageService.ts
@@ -4,6 +4,7 @@ import rimraf from "rimraf";
 import Serverless from "serverless";
 import { FunctionMetadata, Utils } from "../shared/utils";
 import { BaseService } from "./baseService";
+import { constants } from "../shared/constants";
 
 /**
  * Adds service packing support
@@ -145,7 +146,7 @@ export class PackageService extends BaseService {
     const functionObject = this.configService.getFunctionConfig()[functionName];
     const incomingBinding = Utils.getIncomingBindingConfig(functionObject);
     
-    const bindingAzureSettings = Utils.get(incomingBinding, "x-azure-settings", incomingBinding);
+    const bindingAzureSettings = Utils.get(incomingBinding, constants.xAzureSettings, incomingBinding);
 
     if (bindingAzureSettings.route) {
       // Find incoming binding within functionJSON and set the route

--- a/src/shared/utils.test.ts
+++ b/src/shared/utils.test.ts
@@ -105,22 +105,62 @@ describe("utils", () => {
     expect(Utils.getTimestampFromName("")).toEqual(null);
   });
 
-  it("should get incoming binding", () => {
-    expect(Utils.getIncomingBindingConfig(MockFactory.createTestAzureFunctionConfig())).toEqual(
-      {
-        http: true,
-        "x-azure-settings": MockFactory.createTestHttpBinding("in"),
-      }
-    );
+  it("should get incoming binding with x-azure-settings", () => {
+    const functionConfig = MockFactory.createTestAzureFunctionConfig();
+    const actual = Utils.getIncomingBindingConfig(functionConfig);
+    expect(actual).toEqual({
+      http: true,
+      "x-azure-settings": MockFactory.createTestHttpBinding("in"),
+    });
   });
 
-  it("should get outgoing binding", () => {
-    expect(Utils.getOutgoingBinding(MockFactory.createTestAzureFunctionConfig())).toEqual(
-      {
-        http: true,
-        "x-azure-settings": MockFactory.createTestHttpBinding("out"),
-      }
-    );
+  it("should get outgoing binding with x-azure-settings", () => {
+    const functionConfig = MockFactory.createTestAzureFunctionConfig();
+    const actual = Utils.getOutgoingBindingConfig(functionConfig);
+    expect(actual).toEqual({
+      http: true,
+      "x-azure-settings": MockFactory.createTestHttpBinding("out"),
+    });
+  });
+
+  it("should get incoming binding with x-azure-settings if no direction is specified", () => {
+    const functionConfig = MockFactory.createTestAzureFunctionConfig(undefined, true);
+    const actual = Utils.getIncomingBindingConfig(functionConfig);
+    const expected = {
+      http: true,
+      "x-azure-settings": MockFactory.createTestHttpBinding("in"),
+    }
+    delete expected["x-azure-settings"].direction;
+    expect(actual).toEqual(expected);
+  });
+
+  it("should get incoming binding without x-azure-settings", () => {
+    const functionConfig = MockFactory.createTestAzureFunctionConfigWithoutXAzureSettings();
+    const actual = Utils.getIncomingBindingConfig(functionConfig);
+    expect(actual).toEqual({
+      http: true,
+      ...MockFactory.createTestHttpBinding("in"),
+    });
+  });  
+  
+  it("should get outgoing binding without x-azure-settings", () => {
+    const functionConfig = MockFactory.createTestAzureFunctionConfigWithoutXAzureSettings();
+    const actual = Utils.getOutgoingBindingConfig(functionConfig);
+    expect(actual).toEqual({
+      http: true,
+      ...MockFactory.createTestHttpBinding("out"),
+    });
+  });
+
+  it("should get incoming binding without x-azure-settings if no direction is specified", () => {
+    const functionConfig = MockFactory.createTestAzureFunctionConfigWithoutXAzureSettings(undefined, true);
+    const actual = Utils.getIncomingBindingConfig(functionConfig);
+    const expected = {
+      http: true,
+      ...MockFactory.createTestHttpBinding("in"),
+    }
+    delete expected.direction;
+    expect(actual).toEqual(expected);
   });
 
   describe("runWithRetry", () => {

--- a/src/shared/utils.test.ts
+++ b/src/shared/utils.test.ts
@@ -1,6 +1,7 @@
 import Serverless from "serverless";
 import { ConfigService } from "../services/configService";
 import { MockFactory } from "../test/mockFactory";
+import { constants } from "./constants";
 import { FunctionMetadata, Utils } from "./utils";
 
 describe("utils", () => {
@@ -130,7 +131,7 @@ describe("utils", () => {
       http: true,
       "x-azure-settings": MockFactory.createTestHttpBinding("in"),
     }
-    delete expected["x-azure-settings"].direction;
+    delete expected[constants.xAzureSettings].direction;
     expect(actual).toEqual(expected);
   });
 

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -156,14 +156,14 @@ export class Utils {
 
   public static getIncomingBindingConfig(functionConfig: ServerlessAzureFunctionConfig) {
     return functionConfig.events.find((event) => {
-      const settings = event["x-azure-settings"]
+      const settings = Utils.get(event, constants.xAzureSettings, event);
       return settings && (!settings.direction || settings.direction === "in");
     });
   }
 
-  public static getOutgoingBinding(functionConfig: ServerlessAzureFunctionConfig) {
+  public static getOutgoingBindingConfig(functionConfig: ServerlessAzureFunctionConfig) {
     return functionConfig.events.find((event) => {
-      const settings = event["x-azure-settings"]
+      const settings = Utils.get(event, constants.xAzureSettings, event);
       return settings && settings.direction === "out";
     });
   }

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -61,7 +61,13 @@ export class Utils {
       serverless.cli.log(`Building binding for function: ${functionName} event: ${bindingType}`);
 
       bindingUserSettings = {};
-      const azureSettings = events[eventsIndex][constants.xAzureSettings];
+
+      // Merges both the event and event.x-azure-settings for backwards compatibility
+      // Prefers the event and will override anything in x-azure-settings
+      const azureSettings = {
+        ...events[eventsIndex][constants.xAzureSettings],
+        ...events[eventsIndex]
+      };
       let bindingTypeIndex = bindingTypes.indexOf(bindingType);
       const bindingUserSettingsMetaData = BindingUtils.getBindingUserSettingsMetaData(azureSettings, bindingType, bindingTypeIndex, bindingDisplayNames);
 

--- a/src/test/mockFactory.ts
+++ b/src/test/mockFactory.ts
@@ -339,15 +339,36 @@ export class MockFactory {
     };
   }
 
-  public static createTestFunctionMetadata(name: string, xAzureSettings: boolean = true): ServerlessAzureFunctionConfig {
+  public static createTestFunctionMetadata(name: string): ServerlessAzureFunctionConfig {
     return {
       "handler": `${name}.handler`,
-      "events": MockFactory.createTestFunctionEvents(xAzureSettings),
+      "events": MockFactory.createTestFunctionEvents(),
     }
   }
 
-  public static createTestFunctionEvents(xAzureSettings: boolean = true): ServerlessAzureFunctionBindingConfig[] {
-    return (xAzureSettings) ? [
+  public static createTestFunctionEvents(): ServerlessAzureFunctionBindingConfig[] {
+    return [
+      {
+        "http": true,
+        "authLevel": "anonymous"
+      },
+      {
+        "http": true,
+        "direction": "out",
+        "name": "res"
+      }
+    ]
+  }
+
+  public static createTestFunctionMetadataWithXAzureSettings(name: string, xAzureSettings: boolean = true): ServerlessAzureFunctionConfig {
+    return {
+      "handler": `${name}.handler`,
+      "events": MockFactory.createTestFunctionEventsWithXAzureSettings(),
+    }
+  }
+
+  public static createTestFunctionEventsWithXAzureSettings(): ServerlessAzureFunctionBindingConfig[] {
+    return [
       {
         "http": true,
         "x-azure-settings": {
@@ -360,16 +381,6 @@ export class MockFactory {
           "direction": "out",
           "name": "res"
         }
-      }
-    ] : [
-      {
-        "http": true,
-        "authLevel": "anonymous"
-      },
-      {
-        "http": true,
-        "direction": "out",
-        "name": "res"
       }
     ]
   }
@@ -531,14 +542,14 @@ export class MockFactory {
     }
   }
 
-  public static createTestSlsFunctionConfig(xAzureSettings: boolean = true) {
+  public static createTestSlsFunctionConfig() {
     return {
       hello: {
-        ...MockFactory.createTestFunctionMetadata("hello", xAzureSettings),
+        ...MockFactory.createTestFunctionMetadata("hello"),
         ...MockFactory.createTestFunctionApimConfig("hello"),
       },
       goodbye: {
-        ...MockFactory.createTestFunctionMetadata("goodbye", xAzureSettings),
+        ...MockFactory.createTestFunctionMetadata("goodbye"),
         ...MockFactory.createTestFunctionApimConfig("goodbye"),
       },
     };

--- a/src/test/mockFactory.ts
+++ b/src/test/mockFactory.ts
@@ -339,15 +339,15 @@ export class MockFactory {
     };
   }
 
-  public static createTestFunctionMetadata(name: string): ServerlessAzureFunctionConfig {
+  public static createTestFunctionMetadata(name: string, xAzureSettings: boolean = true): ServerlessAzureFunctionConfig {
     return {
       "handler": `${name}.handler`,
-      "events": MockFactory.createTestFunctionEvents(),
+      "events": MockFactory.createTestFunctionEvents(xAzureSettings),
     }
   }
 
-  public static createTestFunctionEvents(): ServerlessAzureFunctionBindingConfig[] {
-    return [
+  public static createTestFunctionEvents(xAzureSettings: boolean = true): ServerlessAzureFunctionBindingConfig[] {
+    return (xAzureSettings) ? [
       {
         "http": true,
         "x-azure-settings": {
@@ -360,6 +360,16 @@ export class MockFactory {
           "direction": "out",
           "name": "res"
         }
+      }
+    ] : [
+      {
+        "http": true,
+        "authLevel": "anonymous"
+      },
+      {
+        "http": true,
+        "direction": "out",
+        "name": "res"
       }
     ]
   }
@@ -431,16 +441,33 @@ export class MockFactory {
     return bindings;
   }
 
-  public static createTestAzureFunctionConfig(route?: string): ServerlessAzureFunctionConfig {
+  public static createTestAzureFunctionConfig(route?: string, excludeDirection?: boolean): ServerlessAzureFunctionConfig {
     return {
       events: [
         {
           http: true,
-          "x-azure-settings": MockFactory.createTestHttpBinding("in", route),
+          "x-azure-settings": MockFactory.createTestHttpBinding((excludeDirection) ? undefined : "in", route),
         },
         {
           http: true,
           "x-azure-settings": MockFactory.createTestHttpBinding("out"),
+        }
+      ],
+      handler: "handler.js",
+    }
+  }
+
+  public static createTestAzureFunctionConfigWithoutXAzureSettings(
+    route?: string, excludeDirection?: boolean): ServerlessAzureFunctionConfig {
+    return {
+      events: [
+        {
+          http: true,
+          ...MockFactory.createTestHttpBinding((excludeDirection) ? undefined : "in", route)
+        },
+        {
+          http: true,
+          ...MockFactory.createTestHttpBinding("out"),
         }
       ],
       handler: "handler.js",
@@ -464,8 +491,8 @@ export class MockFactory {
     return MockFactory.createTestHttpBinding();
   }
 
-  public static createTestHttpBinding(direction: string = "in", route?: string) {
-    if (direction === "in") {
+  public static createTestHttpBinding(direction?: string, route?: string) {
+    if (!direction || direction === "in") {
       return {
         authLevel: "anonymous",
         type: "httpTrigger",
@@ -504,14 +531,14 @@ export class MockFactory {
     }
   }
 
-  public static createTestSlsFunctionConfig() {
+  public static createTestSlsFunctionConfig(xAzureSettings: boolean = true) {
     return {
       hello: {
-        ...MockFactory.createTestFunctionMetadata("hello"),
+        ...MockFactory.createTestFunctionMetadata("hello", xAzureSettings),
         ...MockFactory.createTestFunctionApimConfig("hello"),
       },
       goodbye: {
-        ...MockFactory.createTestFunctionMetadata("goodbye"),
+        ...MockFactory.createTestFunctionMetadata("goodbye", xAzureSettings),
         ...MockFactory.createTestFunctionApimConfig("goodbye"),
       },
     };


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless-azure-functions/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Users can now place the configuration in the event object rather than inside the nested `x-azure-settings` configuration. **Users can still use `x-azure-settings` if they want. This is NOT a breaking change**

Closes #371 and #12 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

- Made `x-azure-settings` to be optional member of interface
- To maintain backwards compatibility, the binding utilities will first check to see if `x-azure-functions` is defined on the event object. If it is not, the event itself is used.
- The Func plugin and service that generate the .yml file were also updated to reflect the change
- Changes to the MockFactory, tests, and documentation were made to reflect the change

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

- Take any existing project, move the settings contained within `x-azure-settings` up one level and run `sls offline`. The bindings are generated correctly

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

_**Note: Run `npm run test:ci` to run all validation checks on proposed changes**_

- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [x] Write documentation
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES  
**_Is it a breaking change?:_** NO
