### PR TITLE
feat: Info plugin and deploy dry run

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,23 @@ $ sls offline -a "--cors *"
 
 This works for `sls offline` or `sls offline start`
 
+### Dry-Run Deployment
+
+Before you deploy your new function app, you may want to double check the resources that will be created, their generated names and other basic configuration info. You can run:
+
+```bash
+# -d is short for --dryrun
+$ sls deploy --dryrun
+```
+
+This will print out a basic summary of what your deployed service will look like.
+
+For a more detailed look into the generated ARM template for your resource group, add the `--arm` (or `-a`) flag:
+
+```bash
+$ sls deploy --dryrun --arm
+```
+
 ### Deploy Your Function App
 
 Deploy your new service to Azure! The first time you do this, you will be asked to authenticate with your Azure account, so the `serverless` CLI can manage Functions on your behalf. Simply follow the provided instructions, and the deployment will continue as soon as the authentication process is completed.
@@ -79,6 +96,26 @@ $ sls deploy
 ```
 
 For more advanced deployment scenarios, see our [deployment docs](docs/DEPLOY.md)
+
+### Get a Summary of Your Deployed Function App
+
+To see a basic summary of your application (same format as the dry-run summary above), run:
+
+```bash
+$ sls info
+```
+
+To look at the ARM template for the last successful deployment, add the `--arm` (or `-a`) flag:
+
+```bash
+$ sls info --arm
+```
+
+You can also get information services with different stages, regions or resource groups by passing any of those flags. Example:
+
+```bash
+$ sls info --stage prod --region westus2
+```
 
 ### Test Your Function App
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { AzureFuncPlugin } from "./plugins/func/azureFuncPlugin";
 import { AzureOfflinePlugin } from "./plugins/offline/azureOfflinePlugin"
 import { AzureRollbackPlugin } from "./plugins/rollback/azureRollbackPlugin"
 import { AzureKeyVaultPlugin } from "./plugins/identity/azureKeyVaultPlugin"
+import { AzureInfoPlugin } from "./plugins/info/azureInfoPlugin";
 
 export default class AzureIndex {
   public constructor(private serverless: Serverless, private options) {
@@ -33,6 +34,7 @@ export default class AzureIndex {
     this.serverless.pluginManager.addPlugin(AzureOfflinePlugin);
     this.serverless.pluginManager.addPlugin(AzureRollbackPlugin);
     this.serverless.pluginManager.addPlugin(AzureKeyVaultPlugin);
+    this.serverless.pluginManager.addPlugin(AzureInfoPlugin);
   }
 }
 

--- a/src/models/serverless.ts
+++ b/src/models/serverless.ts
@@ -1,7 +1,7 @@
-import { ApiManagementConfig } from "./apiManagement";
 import Serverless from "serverless";
-import { ArmParameters } from "./armTemplates";
-import { Runtime, FunctionAppOS } from "../config/runtime";
+import { FunctionAppOS, Runtime } from "../config/runtime";
+import { ApiManagementConfig } from "./apiManagement";
+import { ArmDeployment, ArmParameters } from "./armTemplates";
 
 export interface ArmTemplateConfig {
   file: string;
@@ -196,4 +196,28 @@ export interface ServerlessLogOptions {
   underline?: boolean;
   bold?: boolean;
   color?: string;
+}
+
+export interface AzureResourceInfo {
+  name: string;
+  resourceType: string;
+  region: string;
+}
+
+export interface AzureFunctionAppInfo {
+  name: string;
+  functions: string[];
+}
+
+export interface AzureFunctionInfo {
+  name: string;
+  enabled?: boolean;
+}
+
+export interface ServiceInfo {
+  resourceGroup: string;
+  isDryRun: boolean;
+  resources: AzureResourceInfo[];
+  functionApp?: AzureFunctionAppInfo;
+  deployment?: ArmDeployment;
 }

--- a/src/plugins/apim/azureApimPlugin.ts
+++ b/src/plugins/apim/azureApimPlugin.ts
@@ -13,7 +13,7 @@ export class AzureApimPlugin extends AzureBasePlugin {
 
   private async deploy() {
     const apimConfig = this.serverless.service.provider["apim"];
-    if (!apimConfig) {
+    if (!apimConfig || this.getOption("dryrun")) {
       return Promise.resolve();
     }
 

--- a/src/plugins/azureBasePlugin.ts
+++ b/src/plugins/azureBasePlugin.ts
@@ -63,6 +63,14 @@ export abstract class AzureBasePlugin<TOptions=Serverless.Options> {
     this.loggingService.debug(message);
   }
 
+  protected prettyPrint(object: any) {
+    this.log(this.stringify(object));
+  }
+
+  protected stringify(object: any): string {
+    return JSON.stringify(object, null, 2);
+  }
+
   protected getOption(key: string, defaultValue?: any): string {
     return Utils.get(this.options, key, defaultValue);
   }

--- a/src/plugins/info/azureInfoPlugin.test.ts
+++ b/src/plugins/info/azureInfoPlugin.test.ts
@@ -1,0 +1,33 @@
+import Serverless from "serverless";
+import { MockFactory } from "../../test/mockFactory";
+import { invokeHook } from "../../test/utils";
+import { AzureInfoPlugin } from "./azureInfoPlugin";
+
+jest.mock("../../services/infoService");
+import { AzureInfoService, ServiceInfoType } from "../../services/infoService";
+
+describe("Info Plugin", () => {
+
+  function createPlugin(sls?: Serverless, options?: Serverless.Options) {
+    return new AzureInfoPlugin(
+      sls || MockFactory.createTestServerless(),
+      options || MockFactory.createTestServerlessOptions(),
+    )
+  }
+
+  beforeAll(() => {
+    AzureInfoService.prototype.printInfo = jest.fn();
+  });
+
+  it("calls info service to print dry run", async () => {
+    const plugin = createPlugin(undefined, { "dryrun": "" } as any);
+    await invokeHook(plugin, "info:info");
+    expect(AzureInfoService.prototype.printInfo).toBeCalledWith(ServiceInfoType.DRYRUN)
+  });
+
+  it("calls info service to print dry run", async () => {
+    const plugin = createPlugin();
+    await invokeHook(plugin, "info:info");
+    expect(AzureInfoService.prototype.printInfo).toBeCalledWith(ServiceInfoType.DEPLOYED)
+  });
+});

--- a/src/plugins/info/azureInfoPlugin.ts
+++ b/src/plugins/info/azureInfoPlugin.ts
@@ -1,0 +1,41 @@
+import Serverless from "serverless";
+import { AzureBasePlugin } from "../azureBasePlugin";
+import { constants } from "../../shared/constants";
+import { AzureInfoService, ServiceInfoType } from "../../services/infoService";
+
+export class AzureInfoPlugin extends AzureBasePlugin {
+
+  public constructor(serverless: Serverless, options: Serverless.Options) {
+    super(serverless, options);
+
+    this.hooks = {
+      "info:info": this.executeInfo.bind(this)
+    };
+
+    this.commands = {
+      info: {
+        usage: "Get information about deployed Azure resources for service",
+        lifecycleEvents: [
+          "info",
+        ],
+        options: {
+          ...constants.deployedServiceOptions,
+          dryrun: {
+            usage: "Get a summary for what the deployment would look like",
+            shortcut: "d",
+          },
+          arm: {
+            usage: "Inspect the ARM template of either the last successful deployment or the generated template",
+            shortcut: "a",
+          }
+        }
+      }
+    }
+  }
+
+  private async executeInfo() {
+    const infoService = new AzureInfoService(this.serverless, this.options);
+    const infoType = "dryrun" in this.options ? ServiceInfoType.DRYRUN : ServiceInfoType.DEPLOYED
+    infoService.printInfo(infoType);
+  }
+}

--- a/src/plugins/invoke/azureInvokePlugin.ts
+++ b/src/plugins/invoke/azureInvokePlugin.ts
@@ -3,6 +3,7 @@ import path, { isAbsolute } from "path";
 import Serverless from "serverless";
 import { InvokeService } from "../../services/invokeService";
 import { AzureBasePlugin } from "../azureBasePlugin";
+import { constants } from "../../shared/constants";
 
 export class AzureInvokePlugin extends AzureBasePlugin {
 
@@ -14,26 +15,7 @@ export class AzureInvokePlugin extends AzureBasePlugin {
         usage: "Invoke command",
         lifecycleEvents: ["invoke"],
         options: {
-          resourceGroup: {
-            usage: "Resource group for the service",
-            shortcut: "g",
-          },
-          stage: {
-            usage: "Stage of service",
-            shortcut: "s"
-          },
-          region: {
-            usage: "Region of service",
-            shortcut: "r"
-          },
-          subscriptionId: {
-            usage: "Sets the Azure subscription ID",
-            shortcut: "i",
-          },
-          function: {
-            usage: "Function to call",
-            shortcut: "f",
-          },
+          ...constants.deployedServiceOptions,
           path: {
             usage: "Path to file to put in body",
             shortcut: "p"

--- a/src/plugins/login/loginHooks.ts
+++ b/src/plugins/login/loginHooks.ts
@@ -8,4 +8,5 @@ export const loginHooks = [
   "invoke:invoke",
   "rollback:rollback",
   "remove:remove",
+  "info:info"
 ]

--- a/src/plugins/remove/azureRemovePlugin.ts
+++ b/src/plugins/remove/azureRemovePlugin.ts
@@ -2,6 +2,7 @@ import Serverless from "serverless";
 import { ResourceService } from "../../services/resourceService";
 import { AzureBasePlugin } from "../azureBasePlugin";
 import { Utils } from "../../shared/utils";
+import { constants } from "../../shared/constants";
 
 export class AzureRemovePlugin extends AzureBasePlugin {
 
@@ -15,22 +16,7 @@ export class AzureRemovePlugin extends AzureBasePlugin {
           "remove"
         ],
         options: {
-          resourceGroup: {
-            usage: "Resource group for the service",
-            shortcut: "g",
-          },
-          stage: {
-            usage: "Stage of service",
-            shortcut: "s"
-          },
-          region: {
-            usage: "Region of service",
-            shortcut: "r"
-          },
-          subscriptionId: {
-            usage: "Sets the Azure subscription ID",
-            shortcut: "i",
-          },
+          ...constants.deployedServiceOptions
         }
       }
     }

--- a/src/plugins/rollback/azureRollbackPlugin.ts
+++ b/src/plugins/rollback/azureRollbackPlugin.ts
@@ -1,6 +1,7 @@
 import Serverless from "serverless";
 import { RollbackService } from "../../services/rollbackService";
 import { AzureBasePlugin } from "../azureBasePlugin";
+import { constants } from "../../shared/constants";
 
 /**
  * Plugin for rolling back Function App Service to previous deployment
@@ -21,22 +22,7 @@ export class AzureRollbackPlugin extends AzureBasePlugin {
             usage: "Timestamp of previous deployment",
             shortcut: "t",
           },
-          resourceGroup: {
-            usage: "Resource group for the service",
-            shortcut: "g",
-          },
-          stage: {
-            usage: "Stage of service",
-            shortcut: "s"
-          },
-          region: {
-            usage: "Region of service",
-            shortcut: "r"
-          },
-          subscriptionId: {
-            usage: "Sets the Azure subscription ID",
-            shortcut: "i",
-          },
+          ...constants.deployedServiceOptions
         }
       }
     }

--- a/src/services/baseService.ts
+++ b/src/services/baseService.ts
@@ -38,7 +38,7 @@ export abstract class BaseService {
     this.baseUrl = "https://management.azure.com";
     this.serviceName = this.configService.getServiceName();
     this.credentials = serverless.variables[constants.variableKeys.azureCredentials];
-    this.subscriptionId = this.config.provider.subscriptionId;
+    this.subscriptionId = this.configService.getSubscriptionId();
     this.resourceGroup = this.configService.getResourceGroupName();
     this.deploymentName = this.configService.getDeploymentName();
     this.artifactName = this.configService.getArtifactName(this.deploymentName);

--- a/src/services/configService.ts
+++ b/src/services/configService.ts
@@ -58,7 +58,10 @@ export class ConfigService {
    * Azure Subscription ID
    */
   public getSubscriptionId(): string {
-    return this.config.provider.subscriptionId;
+    return this.getOption(constants.variableKeys.subscriptionId)
+      || process.env.AZURE_SUBSCRIPTION_ID
+      || this.config.provider.subscriptionId
+      || this.serverless.variables[constants.variableKeys.subscriptionId]
   }
 
   /**
@@ -158,6 +161,10 @@ export class ConfigService {
 
     if (!config.provider.os) {
       config.provider.os = os;
+    }
+    
+    if (!config.provider.type) {
+      config.provider.type = "consumption"
     }
   }
 

--- a/src/services/infoService.test.ts
+++ b/src/services/infoService.test.ts
@@ -1,0 +1,255 @@
+import Serverless from "serverless";
+import { ArmDeployment } from "../models/armTemplates";
+import { AzureResourceInfo } from "../models/serverless";
+import { MockFactory } from "../test/mockFactory";
+import { AzureInfoService, ServiceInfoType } from "./infoService";
+
+jest.mock("./armService");
+import { ArmService } from "./armService";
+
+jest.mock("./resourceService");
+import { ResourceService } from "./resourceService";
+
+jest.mock("./functionAppService");
+import { FunctionAppService } from "./functionAppService";
+
+describe("Info Service", () => {
+
+  function createService(sls?: Serverless, options?: any, ) {
+    return new AzureInfoService(sls || MockFactory.createTestServerless(), options || {});
+  }
+
+  const resourceName1 = "My First Resource Name";
+  const resourceLocation1 = "West US 2";
+  const resourceType1 = "Type1";
+  
+  const resourceName2 = "My Second Resource Name";
+  const resourceLocation2 = "West US";
+  const resourceType2 = "Type2"
+
+  const resourceName3 = "My Third Resource Name";
+  const resourceLocation3 = "East US";
+  const resourceType3 = "Type3";
+  
+  const expectedResources: AzureResourceInfo[] = [
+    {
+      name: resourceName1,
+      resourceType: resourceType1,
+      region: resourceLocation1,
+    },
+    {
+      name: resourceName2,
+      resourceType: resourceType2,
+      region: resourceLocation2,
+    },
+    {
+      name: resourceName3,
+      resourceType: resourceType3,
+      region: resourceLocation3,
+    },
+  ]
+
+  describe("Dry Run", () => {
+    const sls = MockFactory.createTestServerless();
+    const resourceGroupName = "My Resource Group";
+    const functionAppName = "My Function App Name";
+
+    sls.service.provider = {
+      ...sls.service.provider,
+      resourceGroup: resourceGroupName,
+      functionApp: {
+        name: functionAppName
+      }
+    } as any;
+
+    const service = createService(sls);
+    const verbose = createService(sls, {"arm": ""});
+    
+    const defaultArmDeployment: ArmDeployment = {
+      parameters: {
+        resourceName1: {
+          defaultValue: resourceName1,
+        },
+        resourceLocation1: {
+          value: resourceLocation1,
+        },
+        resourceType1: {
+          value: resourceType1
+        },
+        resourceLocation2: {
+          defaultValue: resourceLocation2,
+        },
+        resourceName3: {
+          value: resourceName3,
+        },
+      },
+      template: {
+        resources: [
+          {
+            name: "[parameters('resourceName1')]",
+            location: "[parameters('resourceLocation1')]",
+            type: resourceType1,
+          },
+          {
+            name: resourceName2,
+            location: "[parameters('resourceLocation2')]",
+            type: resourceType2,
+          },
+          {
+            name: "[parameters('resourceName3')]",
+            location: resourceLocation3,
+            type: resourceType3,
+          },
+        ]
+      } as any
+    }
+
+    beforeAll(() => {
+      ArmService.prototype.createDeploymentFromType = jest.fn(() => Promise.resolve(defaultArmDeployment));
+
+    });
+
+    it("gets dry-run info by default", async () => {
+      expect((await service.getInfo()).isDryRun).toBe(true);
+      expect((await service.getInfo(ServiceInfoType.DRYRUN)).isDryRun).toBe(true);
+    });
+
+    it("gets correct service service info", async () => {
+      const { resourceGroup, functionApp, resources } = await service.getInfo();
+      expect(resourceGroup).toEqual(resourceGroupName);
+      expect(functionApp.name).toEqual(functionAppName);
+      expect(resources).toEqual(expectedResources);
+      expect(functionApp.functions).toEqual(["hello", "goodbye"]);
+    });    
+
+    it("prints summary", async () => {
+      await service.printInfo();
+      expect(sls.cli.log).lastCalledWith([
+        `\nResource Group Name: ${resourceGroupName}`,
+        `Function App Name: ${functionAppName}`,
+        "Functions:",
+        "\t" + ["hello", "goodbye"].join("\n\t"),
+        "Azure Resources:",
+        expectedResources.map((r) => JSON.stringify(r, null, 2)).join(",\n")
+      ].join("\n"));
+    });
+  
+    it("prints arm template", async () => {
+      await verbose.printInfo();
+      expect(sls.cli.log).lastCalledWith(JSON.stringify(defaultArmDeployment, null, 2));
+    });
+  });
+
+  describe("Deployed", () => {
+    const sls = MockFactory.createTestServerless();
+    const resourceGroupName = "My Resource Group";
+    const functionAppName = "My Function App Name";
+
+    sls.service.provider = {
+      ...sls.service.provider,
+      resourceGroup: resourceGroupName,
+    } as any;
+
+    const service = createService(sls);
+    const verbose = createService(sls, {"arm": ""});
+
+    const mockResourceGroup = {
+      name: resourceGroupName,
+    }
+
+    const listOfFunctions = [
+      { name: "function1" },
+      { name: "function2" },
+      { name: "function3" }
+    ]
+
+    const previouDeploymentTemplate = {
+      $schema: {},
+      resources: []
+    }
+
+    beforeAll(() => {
+      FunctionAppService.prototype.get = jest.fn(() => Promise.resolve({
+        name: functionAppName 
+      })) as any;
+      FunctionAppService.prototype.listFunctions = jest.fn(() => Promise.resolve(listOfFunctions)) as any;
+      ResourceService.prototype.getPreviousDeploymentTemplate = jest.fn(() => Promise.resolve(previouDeploymentTemplate)) as any;
+    })
+
+    it("advises user if resource group is not deployed", async () => {
+      ResourceService.prototype.getResourceGroup = jest.fn(() => Promise.resolve(undefined));
+      await service.getInfo(ServiceInfoType.DEPLOYED);
+      expect(sls.cli.log).lastCalledWith(`Resource group ${resourceGroupName} is not yet deployed`);
+    });
+
+    it("advises user if resource group has no resources", async () => {
+      ResourceService.prototype.getResourceGroup = jest.fn(() => Promise.resolve(mockResourceGroup)) as any;
+      ResourceService.prototype.getResources = jest.fn(() => Promise.resolve([])) as any;
+      await service.getInfo(ServiceInfoType.DEPLOYED);
+      expect(sls.cli.log).lastCalledWith(`Resource group ${resourceGroupName} has no resources`);
+    });
+
+    it("gets correct service info", async () => {
+      const resourceName1 = "My First Resource Name";
+      const resourceLocation1 = "West US 2";
+      const resourceType1 = "Type1";
+      
+      const resourceName2 = "My Second Resource Name";
+      const resourceLocation2 = "West US";
+      const resourceType2 = "Type2"
+
+      const resourceName3 = "My Third Resource Name";
+      const resourceLocation3 = "East US";
+      const resourceType3 = "Type3";
+    
+      const mockResources = [
+        {
+          name: resourceName1,
+          location: resourceLocation1,
+          type: resourceType1,
+        },
+        {
+          name: resourceName2,
+          location: resourceLocation2,
+          type: resourceType2,
+        },
+        {
+          name: resourceName3,
+          location: resourceLocation3,
+          type: resourceType3,
+        },
+      ]
+
+      ResourceService.prototype.getResourceGroup = jest.fn(() => Promise.resolve(mockResourceGroup)) as any;
+      ResourceService.prototype.getResources = jest.fn(() => Promise.resolve(mockResources)) as any;
+      const info = await service.getInfo(ServiceInfoType.DEPLOYED);
+      expect(info).toEqual({
+        resourceGroup: resourceGroupName,
+        isDryRun: false,
+        resources: expectedResources,
+        functionApp: {
+          name: functionAppName,
+          functions: ["function1", "function2", "function3"]
+        },
+        deployment: previouDeploymentTemplate
+      })
+    });
+
+    it("prints summary", async () => {
+      await service.printInfo(ServiceInfoType.DEPLOYED);
+      expect(sls.cli.log).lastCalledWith([
+        `\nResource Group Name: ${resourceGroupName}`,
+        `Function App Name: ${functionAppName}`,
+        "Functions:",
+        "\t" + listOfFunctions.map((f) => f.name).join("\n\t"),
+        "Azure Resources:",
+        expectedResources.map((r) => JSON.stringify(r, null, 2)).join(",\n")
+      ].join("\n"));
+    });
+  
+    it("prints arm template", async () => {
+      await verbose.printInfo(ServiceInfoType.DEPLOYED);
+      expect(sls.cli.log).lastCalledWith(JSON.stringify(previouDeploymentTemplate, null, 2));
+    });
+  });  
+});

--- a/src/services/infoService.ts
+++ b/src/services/infoService.ts
@@ -1,0 +1,159 @@
+import Serverless from "serverless";
+import { FunctionAppResource } from "../armTemplates/resources/functionApp";
+import { ArmParameters } from "../models/armTemplates";
+import { AzureResourceInfo, ServiceInfo } from "../models/serverless";
+import { ArmService } from "./armService";
+import { BaseService } from "./baseService";
+import { FunctionAppService } from "./functionAppService";
+import { ResourceService } from "./resourceService";
+
+/**
+ * Type of information to be presented
+ */
+export enum ServiceInfoType {
+  /** Information on hypothetical deployment */
+  DRYRUN,
+  /** Information reflecting currently deployed resources in resource group */
+  DEPLOYED
+}
+
+/**
+ * Service to collect and present information about the serverless service
+ */
+export class AzureInfoService extends BaseService {
+  
+  public constructor(serverless: Serverless, options: Serverless.Options) {
+    super(serverless, options);
+  }
+
+  /**
+   * Prints information relating to the configuration and infrastructure
+   * of the service. By default, prints a basic summary. If the "-v" or "--verbose"
+   * flag is added, it prints the entire ARM template and parameters
+   * @param infoType Type of information to print.
+   * DRYRUN uses the information that will be configured by the plugin
+   * DEPLOYED uses the information from the actual deployed services in Azure
+   */
+  public async printInfo(infoType: ServiceInfoType = ServiceInfoType.DRYRUN): Promise<void> {
+    const info = await this.getInfo(infoType);
+    if ("arm" in this.options) {
+      this.prettyPrint(info.deployment);
+      return;
+    }
+    this.printSummary(info);
+  }
+
+  /**
+   * Gets the data structure that summarizes the configuration and infrastructure
+   * of the service.
+   * @param infoType Type of information to print.
+   * DRYRUN uses the information that will be configured by the plugin
+   * DEPLOYED uses the information from the actual deployed services in Azure
+   */
+  public async getInfo(infoType: ServiceInfoType = ServiceInfoType.DRYRUN): Promise<ServiceInfo> {
+    return (infoType === ServiceInfoType.DRYRUN) ? await this.getDryRun() : await this.getDeployed();
+  }
+
+  private async getDeployed(): Promise<ServiceInfo> {
+    const resourceService = new ResourceService(this.serverless, this.options);
+    const resourceGroup = await resourceService.getResourceGroup();
+    if (!resourceGroup) {
+      this.log(`Resource group ${this.resourceGroup} is not yet deployed`);
+      return;
+    }
+    const resources = await resourceService.getResources();
+    if (!resources.length) {
+      this.log(`Resource group ${this.resourceGroup} has no resources`);
+      return;
+    }
+
+    const functionAppService = new FunctionAppService(this.serverless, this.options);
+    const functionApp = await functionAppService.get();
+    const functions = await functionAppService.listFunctions(functionApp);
+
+    return {
+      resourceGroup: this.resourceGroup,
+      isDryRun: false,
+      resources: resources.map((r) => {
+        const info: AzureResourceInfo = {
+          name: r.name,
+          resourceType: r.type,
+          region: r.location
+        }
+        return info;
+      }),
+      functionApp: {
+        name: functionApp.name,
+        functions: functions.map((f) => f.name),
+      },
+      deployment: await resourceService.getPreviousDeploymentTemplate()
+    }
+  }
+
+  /**
+   * Prints the service info in a summarized, readable manner
+   * @param serviceInfo Data structure describing service
+   */
+  private async printSummary(serviceInfo: ServiceInfo) {
+    if (!serviceInfo) {
+      return;
+    }
+    const printVersion = [
+      `\nResource Group Name: ${serviceInfo.resourceGroup}`,
+      `Function App Name: ${serviceInfo.functionApp.name}`,
+      "Functions:",
+      "\t" + serviceInfo.functionApp.functions.map((f) => `${f}`).join("\n\t"),
+      "Azure Resources:",
+      serviceInfo.resources.map((r) => this.stringify(r)).join(",\n")
+    ].join("\n");
+    this.log(printVersion);
+  }
+
+  /**
+   * Create the dry-run data structure. Assembles the `ServiceInfo` based on what
+   * would be deployed if it were run. Collects names of Azure resources from generated
+   * ARM template and replaces the parameter stubs with the actual name
+   */
+  private async getDryRun(): Promise<ServiceInfo> {
+    const armService = new ArmService(this.serverless, this.options);
+    const { parameters, template } = await armService.createDeploymentFromType(this.config.provider.type);
+    const resources: AzureResourceInfo[] = template.resources.map((resource) => {
+      const info: AzureResourceInfo = {
+        name: this.parametersValueReplace(resource.name, parameters),
+        resourceType: resource.type,
+        region: this.parametersValueReplace(resource.location, parameters),
+      }
+      return info;
+    });
+
+    return {
+      resourceGroup: this.configService.getResourceGroupName(),
+      isDryRun: true,
+      resources,
+      functionApp: {
+        name: FunctionAppResource.getResourceName(this.config),
+        functions: Object.keys(this.configService.getFunctionConfig()),
+      },
+      deployment: {
+        parameters,
+        template
+      }
+    };
+  }
+
+  /**
+   * Returns the name that will be used by the ARM template. If it is a parameterized name, it will
+   * return the correct replacement value. If not, it will return the original value
+   * @param original Parameter stub or original value. Should be something like `[parameters('myParamName')]`
+   * @param parameters Object containing parameter values (e.g. { myParamName: 'ThisIsMyParamName' })
+   */
+  private parametersValueReplace(original: string, parameters: ArmParameters): string {
+    const match = original.match(/\[parameters\('(.*)'\)\]/i);
+    if (!match || match.length < 2) {
+      return original;
+    }
+    const key = match[1];
+    const { defaultValue, value } = parameters[key];
+    return (value ? value : defaultValue) as string;
+  }
+}

--- a/src/services/resourceService.ts
+++ b/src/services/resourceService.ts
@@ -114,6 +114,14 @@ export class ResourceService extends BaseService {
     }
   }
 
+  public async getResources() {
+    try {
+      return await this.resourceClient.resources.listByResourceGroup(this.resourceGroup);
+    } catch (e) {
+      return undefined;
+    }
+  }
+
   public async deleteDeployment() {
     this.log(`Deleting deployment: ${this.deploymentName}`);
     return await this.resourceClient.deployments.deleteMethod(this.resourceGroup, this.deploymentName);

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -33,5 +33,27 @@ export const constants = {
   runtimeExtensions: {
     nodejs: ".js",
     python: ".py"
+  },
+  deployedServiceOptions: {
+    resourceGroup: {
+      usage: "Resource group for the service",
+      shortcut: "g",
+    },
+    stage: {
+      usage: "Stage of service",
+      shortcut: "s"
+    },
+    region: {
+      usage: "Region of service",
+      shortcut: "r"
+    },
+    subscriptionId: {
+      usage: "Sets the Azure subscription ID",
+      shortcut: "i",
+    },
+    function: {
+      usage: "Deployment of individual function - NOT SUPPORTED",
+      shortcut: "f",
+    }
   }
 }


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless-azure-functions/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

An `info` command and a `--dryrun` option for deployment. This provides users a summary of the deployment that will or has happened without having to leave the CLI

Closes #7 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

- Added an `info` plugin, with an accompanying service
- Added a `--dryrun` option to deploy plugin, which calls the `InfoService`

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

For a service that's already deployed:
```bash
sls info
```
To print the ARM template of most recent successful deployment:
```bash
sls info --arm
```
To get a summary of the service before deployment:
```bash
sls deploy --dryrun
```
To print the generated ARM template before deployment:
```bash
sls deploy --dryrun --arm
```

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

_**Note: Run `npm run test:ci` to run all validation checks on proposed changes**_

- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [x] Write documentation
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
