### PR TITLE
feat: Use cross-spawn instead of adding .cmd

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -23,5 +23,6 @@ module.exports = {
     "json",
     "jsx",
     "node"
-  ]
+  ],
+  "setupFilesAfterEnv": ["jest-os-detection"]
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -4052,13 +4052,41 @@
       }
     },
     "cross-spawn": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.2.tgz",
+      "integrity": "sha512-PD6G8QG3S4FK/XCGFbEQrDqO2AnMMsy0meR7lerlIOHAAbkuavGU/pOqprrlvfTNjvowivTeBsjebAL0NSoMxw==",
       "requires": {
-        "lru-cache": "^4.0.1",
-        "shebang-command": "^1.2.0",
-        "which": "^1.2.9"
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "dependencies": {
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
       }
     },
     "crypt": {
@@ -5030,6 +5058,18 @@
         "p-finally": "^1.0.0",
         "signal-exit": "^3.0.0",
         "strip-eof": "^1.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
+        }
       }
     },
     "exit": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7680,6 +7680,12 @@
         "@jest/types": "^24.8.0"
       }
     },
+    "jest-os-detection": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/jest-os-detection/-/jest-os-detection-1.1.1.tgz",
+      "integrity": "sha512-StU07rQi0JD8lATH4BbpSZD6jUSj14n4A6Ib5OwOU/DyoVAOum6odcLVj4BhJCOAN5LpZ6nNv9r4wgR+duT4TA==",
+      "dev": true
+    },
     "jest-pnp-resolver": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz",

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "eslint": "^5.16.0",
     "jest": "^24.8.0",
     "jest-cli": "^24.8.0",
+    "jest-os-detection": "^1.1.1",
     "mock-fs": "^4.10.0",
     "mock-spawn": "^0.2.6",
     "serverless": "^1.44.1",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "acorn": "^7.0.0",
     "axios": "^0.18.0",
     "azure-functions-core-tools": "^3.0.2245",
+    "cross-spawn": "^7.0.2",
     "deep-equal": "^1.0.1",
     "js-yaml": "^3.13.1",
     "jsonpath": "^1.0.1",

--- a/src/shared/utils.ts
+++ b/src/shared/utils.ts
@@ -4,7 +4,8 @@ import { ServerlessAzureConfig, ServerlessAzureFunctionConfig } from "../models/
 import { BindingUtils } from "./bindings";
 import { constants } from "./constants";
 import { createInterface } from "readline"
-import { SpawnOptions, spawn, StdioOptions } from "child_process";
+import { SpawnOptions, StdioOptions } from "child_process";
+import { spawn } from "cross-spawn"
 import { getRuntimeLanguage } from "../config/runtime";
 
 export interface FunctionMetadata {
@@ -235,11 +236,6 @@ export class Utils {
       ".bin",
       command
     );
-    
-    // Append .cmd if running on windows
-    if (process.platform === "win32") {
-      localCommand += ".cmd";
-    }
 
     const env = {
       // Inherit environment from current process, most importantly, the PATH


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless-azure-functions/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Instead of manually checking for the operating system, this uses the well known package `cross-spawn` (142M downloads per month) to spawn the process across operating systems.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Replaced the call to `child_process.spawn` with `cross-spawn.spawn`. Also added `jest-os-detection` that will only test the spawn calls the way that they should be expected on that native os rather than defining a property on the `process` object

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

Run `sls offline`. It will spawn on any operating system. Run `npm test` on mac, linux or windows. You'll see that 8 tests are skipped on any OS (each OS has 4 tests)

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

_**Note: Run `npm run test:ci` to run all validation checks on proposed changes**_

- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [x] Write documentation
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
