### PR TITLE
fix: Remove -v shortcut for --verbose, conflicts with --version

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,12 +228,12 @@ The getting started walkthrough illustrates the interactive login experience, wh
 
 ### Logging Verbosity
 
-You can set the logging verbosity with the `--verbose` flag (`-v` for short). If the `--verbose` flag is set with no value, logging will be as verbose as possible (debug mode). You can also provide a value with the flag to set the verbosity to a specific level:
+You can set the logging verbosity with the `--verbose` flag. If the `--verbose` flag is set with no value, logging will be as verbose as possible (debug mode). You can also provide a value with the flag to set the verbosity to a specific level:
 
-- `-v error` - Only error messages printed
-- `-v warn` - Only error and warning messages printed
-- `-v info` - Only error, warning and info messages printed
-- `-v debug` - All messages printed
+- `--verbose error` - Only error messages printed
+- `--verbose warn` - Only error and warning messages printed
+- `--verbose info` - Only error, warning and info messages printed
+- `--verbose debug` - All messages printed
 
 ### Contributing
 

--- a/src/services/loggingService.test.ts
+++ b/src/services/loggingService.test.ts
@@ -51,5 +51,5 @@ describe("Logging Service", () => {
     loggingService = createService(sls, {"verbose": ""});
     loggingService.debug("Debug");
     expect(sls.cli.log).toBeCalledWith("[DEBUG] Debug");
-  })
+  });
 });

--- a/src/services/loggingService.ts
+++ b/src/services/loggingService.ts
@@ -25,18 +25,15 @@ export class LoggingService {
     
     // Check for 'verbose' or 'v'. Would use the sls shortcuts at the plugin level, 
     // but this will be utilized across the plugins, so we check for both
-    const logLevelStr = Utils.get(
-      options,
-      "verbose",
-      Utils.get(options, "v", "info")).toLowerCase();
-    
-    this.logLevel = Utils.get({
+    const logLevelStr = Utils.get(options, "verbose");
+
+    this.logLevel = (logLevelStr !== undefined) ? Utils.get({
       "error": LogLevel.ERROR,
       "warn": LogLevel.WARN,
       "info": LogLevel.INFO,
       "debug": LogLevel.DEBUG,
       "": LogLevel.DEBUG
-    }, logLevelStr, LogLevel.INFO);
+    }, logLevelStr.toLowerCase()) : LogLevel.INFO;
   }
 
   /**


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless-azure-functions/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Currently, if you were to run `sls --version` or `sls -v`, the plugin causes it to fail because the `LoggingService` creates a shortcut for `--verbose`, which is `-v`. This conflicts with `--version`. This PR removes that shortcut and updates the documentation.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Only look for the full `verbose` flag within the options, set log level to `info` if undefined.

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

Run `sls --version`. It shouldn't fail.

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

_**Note: Run `npm run test:ci` to run all validation checks on proposed changes**_

- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [x] Write documentation
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
