### PR TITLE
feat: Add the supportsHttpsTrafficOnly parametrization for StorageAcc…

### DIFF
--- a/src/armTemplates/resources/storageAccount.ts
+++ b/src/armTemplates/resources/storageAccount.ts
@@ -7,6 +7,7 @@ interface StorageAccountParams extends DefaultArmParams {
   storageAccountName: ArmParameter;
   storageAccountSkuName: ArmParameter;
   storageAccountSkuTier: ArmParameter;
+  storageHttpsTrafficOnly: ArmParameter;
 }
 
 export class StorageAccountResource implements ArmResourceTemplateGenerator {
@@ -39,7 +40,11 @@ export class StorageAccountResource implements ArmResourceTemplateGenerator {
       storageAccountSkuTier: {
         defaultValue: "Standard",
         type: ArmParamType.String
-      }
+      },
+      storageHttpsTrafficOnly: {
+        defaultValue: false,
+        type: ArmParamType.Bool
+      },
     }
     return {
       "$schema": "https://schema.management.azure.com/schemas/2015-01-01/deploymentTemplate.json#",
@@ -54,7 +59,8 @@ export class StorageAccountResource implements ArmResourceTemplateGenerator {
           location: "[parameters('location')]",
           kind: "Storage",
           properties: {
-            accountType: "[parameters('storageAccountSkuName')]"
+            accountType: "[parameters('storageAccountSkuName')]",
+            supportsHttpsTrafficOnly: "[parameters('storageHttpsTrafficOnly')]"
           },
           sku: {
             name: "[parameters('storageAccountSkuName')]",
@@ -80,7 +86,10 @@ export class StorageAccountResource implements ArmResourceTemplateGenerator {
       },
       storageAccountSkuTier: {
         value: resourceConfig.sku.tier,
-      }
+      },
+      storageHttpsTrafficOnly: {
+        value: resourceConfig.httpsTrafficOnly
+      },
     };
 
     return params as unknown as ArmParameters;

--- a/src/models/serverless.ts
+++ b/src/models/serverless.ts
@@ -14,6 +14,7 @@ export interface ResourceConfig {
     name?: string;
     tier?: string;
   };
+  httpsTrafficOnly?: boolean;
   [key: string]: any;
 }
 


### PR DESCRIPTION
Add the supportsHttpsTrafficOnly parametrization for Storage Account.
This allows to specify by parameter if strict https communication is required.

## What did you implement:

Closes #438

## How did you implement it:
Added the parameter 

## How can we verify it:

Add  on the serverles.yml file
```yaml
provider:
  ...
  storageAccount:
    httpsTrafficOnly: true
```
And verify the created resource has been created with the storageHttpsTrafficOnly option as if it were true.
<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

_**Note: Run `npm run test:ci` to run all validation checks on proposed changes**_

- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [ ] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [ ] Write documentation
- [ ] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES  
**_Is it a breaking change?:_** NO
