### PR TITLE
fix: Add functionAppReserved back into ARM template

### DIFF
--- a/src/armTemplates/resources/functionApp.test.ts
+++ b/src/armTemplates/resources/functionApp.test.ts
@@ -239,10 +239,12 @@ describe("Function App Resource", () => {
       function assertLinuxParams(parameters: ArmParameters) {
         const { 
           functionAppKind,
+          functionAppReserved,
           functionAppEnableRemoteBuild,
         } = parameters;
 
         expect(functionAppKind.value).toEqual("functionapp,linux");
+        expect(functionAppReserved.value).toBe(true);
         expect(functionAppEnableRemoteBuild.value).toBe(true);
       }
     });
@@ -283,10 +285,12 @@ describe("Function App Resource", () => {
         const {
           linuxFxVersion,
           functionAppKind,
+          functionAppReserved,
         } = parameters;
 
         expect(functionAppKind.value).toBeUndefined();
         expect(linuxFxVersion.value).toBeUndefined();
+        expect(functionAppReserved.value).toBeUndefined();
       }
     });
   });

--- a/src/armTemplates/resources/functionApp.ts
+++ b/src/armTemplates/resources/functionApp.ts
@@ -19,6 +19,10 @@ interface FunctionAppParams extends DefaultArmParams {
    */
   functionAppKind: ArmParameter;
   /**
+   * Needs to be `true` for Linux function apps
+   */
+  functionAppReserved: ArmParameter;
+  /**
    * Docker image for Linux function app
    */
   linuxFxVersion: ArmParameter;
@@ -94,6 +98,7 @@ export class FunctionAppResource implements ArmResourceTemplateGenerator {
               appSettings: this.getFunctionAppSettings(config), 
               "linuxFxVersion": "[parameters('linuxFxVersion')]",
             },
+            "reserved": "[parameters('functionAppReserved')]",
             name: "[parameters('functionAppName')]",
             "clientAffinityEnabled": false,
             "hostingEnvironment": ""
@@ -126,6 +131,9 @@ export class FunctionAppResource implements ArmResourceTemplateGenerator {
       },
       functionAppKind: {
         value: (isLinuxRuntime) ? "functionapp,linux" : undefined,
+      },
+      functionAppReserved: {
+        value: (isLinuxRuntime) ? true : undefined,
       },
       linuxFxVersion: {
         value: (isLinuxRuntime) ? this.getLinuxFxVersion(config) : undefined,
@@ -161,6 +169,10 @@ export class FunctionAppResource implements ArmResourceTemplateGenerator {
       functionAppKind: {
         defaultValue: "functionapp",
         type: ArmParamType.String,
+      },
+      functionAppReserved: {
+        defaultValue: false,
+        type: ArmParamType.Bool
       },
       linuxFxVersion: {
         defaultValue: "",


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless-azure-functions/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Fixes issue of consumption linux function apps not being able to deploy

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Re-added `reserved` property to ARM template

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

Deploy a linux azure function app

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

_**Note: Run `npm run test:ci` to run all validation checks on proposed changes**_

- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [x] Write documentation
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
