### PR TITLE
fix: Log functions in external deployment

### DIFF
--- a/src/services/functionAppService.ts
+++ b/src/services/functionAppService.ts
@@ -166,8 +166,8 @@ export class FunctionAppService extends BaseService {
         constants.runFromPackageSetting,
         sasUrl
       );
-
       await this.syncTriggers(functionApp, response.properties);
+      await this.logFunctions(functionApp);
     } else {
       await Promise.all([
         // Uploaded to blob storage as artifact for future reference
@@ -288,7 +288,10 @@ export class FunctionAppService extends BaseService {
 
     this.log("Deploying serverless functions...");
     await this.uploadZippedArtifactToFunctionApp(functionApp, functionZipFile);
+    await this.logFunctions(functionApp);
+  }
 
+  private async logFunctions(functionApp: Site) {
     this.log("Deployed serverless functions:");
     const serverlessFunctions = this.serverless.service.getAllFunctions();
     const deployedFunctions = await this.listFunctions(functionApp);


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless-azure-functions/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

In external deployment (always the case for .NET on linux), the deployed functions were not listed in the publishing process. This PR adds that fix.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

- Abstracted out `logFunctions` method
- Added call to `logFunctions` after invoking `syncTriggers`

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

- Deploy a function app with `provider.deployment.external` set to true in `serverless.yml`
- You should see the functions listed after publishing

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

_**Note: Run `npm run test:ci` to run all validation checks on proposed changes**_

- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [x] Write documentation
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
