### PR TITLE
ci: Generate changelog in versioning script

### DIFF
--- a/scripts/condenseChangelog.js
+++ b/scripts/condenseChangelog.js
@@ -38,7 +38,7 @@ const compareUrl = baseUrl + "compare/";
  * 
  * ### Bug Fixes
  * * Bug Fix 2
- * * Bug FIx 1
+ * * Bug Fix 1
  * 
  * @param {string} changelog String content of changelog file 
  */
@@ -67,7 +67,6 @@ function generateMarkdown(condensed) {
     const preferredCommitTypes = [ "### Features", "### Bug Fixes" ]
 
     const commitTypes = Object.keys(condensed[releaseVersion]);
-
 
     if (!commitTypes.length) {
       result += "\n\n";
@@ -113,7 +112,7 @@ function commitsToMarkdown(commitType, commitTypeMap) {
 function groupLines(lines) {
   const condensed = {}
   /** Non-beta version */
-  let currentVersion = null;
+  let currentVersion = process.argv[2];
   /** Commit type ("### Bug Fixes", "### Features", etc.) */
   let currentCommitTypeHeader = null;
 
@@ -130,6 +129,10 @@ function groupLines(lines) {
     // Commit type line
     if (line.startsWith("### ")) {
       currentCommitTypeHeader = line;
+      if (!condensed[currentVersion]) {
+        condensed[currentVersion] = {}
+      }
+
       if (!condensed[currentVersion][currentCommitTypeHeader]) {
           condensed[currentVersion][currentCommitTypeHeader] = [];
       }

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -23,14 +23,14 @@ echo "Checked out branch: ${SOURCE_BRANCH_NAME}"
 NPM_VERSION=`npm version ${NPM_RELEASE_TYPE} -m "release: Update ${NPM_RELEASE_TYPE} version to %s ***NO_CI***"`
 echo "Set NPM version to: ${NPM_VERSION}"
 
-if [[ ${NPM_RELEASE_TYPE} == "prerelease"]];
+if [ ${NPM_RELEASE_TYPE} = "prerelease" ]
 then
   npm run changelog;
 else
   npm run changelog:condensed -- ${NPM_VERSION};
 fi
 
-git commit -a --amend
+git commit -a --amend --no-edit
 
 SHA=`git rev-parse HEAD`
 

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -13,8 +13,8 @@ SOURCE_BRANCH_NAME=${SOURCE_BRANCH/refs\/heads\/}
 
 # Configure git to commit as SLS Azure Functions Service Account
 echo "Configuring git to use service account..."
-git config --local user.email "Serverless Azure Functions"
-git config --local user.name "sls-az@microsoft.com"
+git config --local user.name "Serverless Azure Functions"
+git config --local user.email "sls-az@microsoft.com"
 
 git pull origin ${SOURCE_BRANCH_NAME}
 git checkout ${SOURCE_BRANCH_NAME}
@@ -22,6 +22,15 @@ echo "Checked out branch: ${SOURCE_BRANCH_NAME}"
 
 NPM_VERSION=`npm version ${NPM_RELEASE_TYPE} -m "release: Update ${NPM_RELEASE_TYPE} version to %s ***NO_CI***"`
 echo "Set NPM version to: ${NPM_VERSION}"
+
+if [[ ${NPM_RELEASE_TYPE} == "prerelease"]];
+then
+  npm run changelog;
+else
+  npm run changelog:condensed -- ${NPM_VERSION};
+fi
+
+git commit -a --amend
 
 SHA=`git rev-parse HEAD`
 


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless-azure-functions/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Generate the changelog on merges to dev or master. Generates condensed changelog if merges to master

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

- If a release type is prerelease, it will generate a full changelog, but if not prerelease, it will generate a condensed changelog
- Corrected switch of name and email for local git config
- Script for condensing changelog now accepts an argument for the new NPM version rather than depending on a tag to exist (tags are created and pushed after this point)

<!-- 
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

- Run `npm run changelog:condensed -- 2.0.0` (this will be the command executed when pipeline is run). The generated changelog should contain all changes in v2

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

_**Note: Run `npm run test:ci` to run all validation checks on proposed changes**_

- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [x] Write documentation
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
