### PR TITLE
fix: Update .NET to use remote build

### DIFF
--- a/.github/workflows/integration-tests-node.yml
+++ b/.github/workflows/integration-tests-node.yml
@@ -36,7 +36,7 @@ jobs:
     
     # Run the integration test
     - name: package, deploy, invoke, remove
-      run: npm run test:int -- -t deploy.* -d '${{ matrix.runtime }}-${{ matrix.os }}(-external|-webpack)?'
+      run: npm run test:int -- -t deploy.* -d '${{ matrix.runtime }}-${{ matrix.os }}(-webpack)?'
       env:
         AZURE_SUBSCRIPTION_ID: ${{ secrets.AZURE_SUBSCRIPTION_ID}}
         AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID}}

--- a/integrationTests/configurations/dotnet22-linux/serverless.yml
+++ b/integrationTests/configurations/dotnet22-linux/serverless.yml
@@ -14,6 +14,16 @@ provider:
 plugins:
   - serverless-azure-functions
 
+package:
+  exclude:
+    - local.settings.json
+    - .vscode/**
+    - node_modules/**
+    - .funcignore
+    - package.json
+    - package-lock.json
+    - data.json
+
 functions:
   hello:
     handler: hello

--- a/integrationTests/configurations/dotnet31-linux/serverless.yml
+++ b/integrationTests/configurations/dotnet31-linux/serverless.yml
@@ -14,6 +14,16 @@ provider:
 plugins:
   - serverless-azure-functions
 
+package:
+  exclude:
+    - local.settings.json
+    - .vscode/**
+    - node_modules/**
+    - .funcignore
+    - package.json
+    - package-lock.json
+    - data.json
+
 functions:
   hello:
     handler: hello

--- a/src/plugins/package/azurePackagePlugin.ts
+++ b/src/plugins/package/azurePackagePlugin.ts
@@ -4,7 +4,7 @@ import { ServerlessCliCommand } from "../../models/serverless";
 import AzureProvider from "../../provider/azureProvider";
 import { PackageService } from "../../services/packageService";
 import { AzureBasePlugin } from "../azureBasePlugin";
-import { isCompiledRuntime, BuildMode } from "../../config/runtime";
+import { isCompiledRuntime, BuildMode, FunctionAppOS } from "../../config/runtime";
 import { CompilerService } from "../../services/compilerService"
 
 export class AzurePackagePlugin extends AzureBasePlugin {
@@ -18,7 +18,7 @@ export class AzurePackagePlugin extends AzureBasePlugin {
       "before:webpack:package:packageModules": this.webpack.bind(this),
       "after:package:finalize": this.finalize.bind(this),
     };
-    if (isCompiledRuntime(this.config.provider.runtime)) {
+    if (isCompiledRuntime(this.config.provider.runtime) && this.config.provider.os === FunctionAppOS.WINDOWS) {
       delete this.serverless.pluginManager.hooks["package:createDeploymentArtifacts"]
       this.hooks["package:createDeploymentArtifacts"] = this.compileArtifact.bind(this);
     }

--- a/src/services/configService.ts
+++ b/src/services/configService.ts
@@ -250,11 +250,6 @@ export class ConfigService {
       ...deployment,
     }
 
-    if (getRuntimeLanguage(runtime) === RuntimeLanguage.DOTNET && os === FunctionAppOS.LINUX) {
-      this.serverless.cli.log("Linux .NET Function apps must run from external package")
-      config.provider.deployment.external = true
-    }
-
     this.serverless.variables[constants.variableKeys.providerConfig] = config.provider;
     return config;
   }


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless-azure-functions/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Because the `syncTriggers` API that is used for "external" packages being published to a function app, this updates the .NET Core function apps to use the remote build option.

It also removes the "external" integration test calls in the GitHub workflow for Node function apps

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

- Checked for the OS in the package plugin before replacing the hook
- Remove call in config service to force .NET on linux to have `provider.external` to be true
- Remove `-external` from regex when invoking integration tests for node

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

Run the integration tests - .NET core on Linux should be much more stable, similar to python

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

_**Note: Run `npm run test:ci` to run all validation checks on proposed changes**_

- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [x] Write documentation
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
