### PR TITLE
fix: Fix log level setting to handle --verbose

### DIFF
--- a/src/services/loggingService.test.ts
+++ b/src/services/loggingService.test.ts
@@ -46,9 +46,9 @@ describe("Logging Service", () => {
     expect(sls.cli.log).lastCalledWith("[ERROR] Error");
   });
 
-  it("empty string as option value sets logging level to debug", () => {
+  it("boolean as option value sets logging level to debug", () => {
     const sls = MockFactory.createTestServerless();
-    loggingService = createService(sls, {"verbose": ""});
+    loggingService = createService(sls, {"verbose": true});
     loggingService.debug("Debug");
     expect(sls.cli.log).toBeCalledWith("[DEBUG] Debug");
   });

--- a/src/services/loggingService.ts
+++ b/src/services/loggingService.ts
@@ -22,18 +22,25 @@ export class LoggingService {
   private logLevel: LogLevel;
 
   public constructor(private serverless: Serverless, private options: ServerlessAzureOptions) {
-    
-    // Check for 'verbose' or 'v'. Would use the sls shortcuts at the plugin level, 
-    // but this will be utilized across the plugins, so we check for both
-    const logLevelStr = Utils.get(options, "verbose");
+    const verbosity = Utils.get(options, "verbose");
+    const defaultLogLevel = LogLevel.INFO;
 
-    this.logLevel = (logLevelStr !== undefined) ? Utils.get({
-      "error": LogLevel.ERROR,
-      "warn": LogLevel.WARN,
-      "info": LogLevel.INFO,
-      "debug": LogLevel.DEBUG,
-      "": LogLevel.DEBUG
-    }, logLevelStr.toLowerCase()) : LogLevel.INFO;
+    if (verbosity === true) {
+      // --verbose flag is passed with no specified level
+      this.logLevel = LogLevel.DEBUG;
+    } else if (typeof verbosity === "string") {
+      // --verbose {level} is passed
+      this.logLevel = Utils.get({
+        "error": LogLevel.ERROR,
+        "warn": LogLevel.WARN,
+        "info": LogLevel.INFO,
+        "debug": LogLevel.DEBUG,
+        "": LogLevel.DEBUG
+      }, verbosity.toLowerCase(), defaultLogLevel);
+    } else {
+      // --verbose not passed, use default
+      this.logLevel = defaultLogLevel;
+    }    
   }
 
   /**


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless-azure-functions/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Fix log level setting to handle boolean case, previously expected empty string

Closes #470 

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

Updated the conditions to check for boolean in `--verbose` option, set to most verbose level

<!--
If this is a nontrivial change please briefly describe your implementation so its easy for us to understand and review your code.
-->

## How can we verify it:

Run a command with `--verbose` on the end. Previously failed

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

_**Note: Run `npm run test:ci` to run all validation checks on proposed changes**_

- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [x] Write documentation
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES  
**_Is it a breaking change?:_** NO
