### PR TITLE
fix: Check for valid index before setting name property

### DIFF
--- a/src/services/packageService.ts
+++ b/src/services/packageService.ts
@@ -151,8 +151,10 @@ export class PackageService extends BaseService {
     if (this.configService.isPythonTarget()) {
       const index = (functionJSON.bindings as any[])
         .findIndex((binding) => (!binding.direction || binding.direction === "out"));
-      functionJSON.bindings[index].name = "$return";
-    } else {
+
+      if (functionJSON.bindings[index]) {
+        functionJSON.bindings[index].name = "$return";
+      }
     }
     functionJSON.scriptFile = handlerPath;
 

--- a/src/services/packageService.ts
+++ b/src/services/packageService.ts
@@ -108,7 +108,7 @@ export class PackageService extends BaseService {
           rimraf.sync(folderPath);
         }
       });
-      
+
       // Delete function folder if empty
       const items = fs.readdirSync(functionName);
       if (items.length === 0) {
@@ -122,7 +122,7 @@ export class PackageService extends BaseService {
         fs.unlinkSync(filePath);
       }
     }
-    
+
     for (const dir of rootFoldersToRemove) {
       const dirPath = path.join(this.serverless.config.servicePath, dir);
       if (fs.existsSync(dirPath)) {
@@ -160,7 +160,7 @@ export class PackageService extends BaseService {
 
     const functionObject = this.configService.getFunctionConfig()[functionName];
     const incomingBinding = Utils.getIncomingBindingConfig(functionObject);
-    
+
     const bindingAzureSettings = Utils.get(incomingBinding, constants.xAzureSettings, incomingBinding);
 
     if (bindingAzureSettings.route) {
@@ -168,7 +168,9 @@ export class PackageService extends BaseService {
       const index = (functionJSON.bindings as any[])
         .findIndex((binding) => (!binding.direction || binding.direction === "in"));
 
-      functionJSON.bindings[index].route = bindingAzureSettings.route;
+      if (functionJSON.bindings[index]) {
+        functionJSON.bindings[index].route = bindingAzureSettings.route;
+      }
     }
 
     return functionJSON;


### PR DESCRIPTION
This commit fixes a bug when using the timer trigger where it tries to set the name of the binding. The name of the binding can't be set since there is no index found (-1)

Fixes: #444 