### PR TITLE
Make queueName and topicName as not required in ServiceBus outbinding…

### DIFF
--- a/src/shared/bindings.json
+++ b/src/shared/bindings.json
@@ -1022,7 +1022,7 @@
           "name": "queueName",
           "value": "string",
           "defaultValue": "outqueue",
-          "required": true,
+          "required": false,
           "label": "$serviceBusOut_queueName_label",
           "help": "$serviceBusOut_queueName_help",
           "validators": [
@@ -1036,7 +1036,7 @@
           "name": "topicName",
           "value": "string",
           "defaultValue": "outtopic",
-          "required": true,
+          "required": false,
           "label": "$serviceBusOut_topicName_label",
           "help": "$serviceBusOut_topicName_help",
           "validators": [


### PR DESCRIPTION
…. Otherwise generated functions.json will include topicName and queueName with default value.

## What did you implement:

Closes #352

## How did you implement it:

The service bus binding need either queueName or topicName

## How can we verify it:

I link it to my project which use service bus out binding with topic and did a sls deploy. Verify the function.json only contain topicName instead of both topicName and queueName attribute.

## Todos:

Need the ability to require either attribute. Basically we need the ability to specify topicName or queueName is required.

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
