### PR TITLE
feat: add provider parameter use32BitWorkerProcess

### DIFF
--- a/src/armTemplates/resources/functionApp.test.ts
+++ b/src/armTemplates/resources/functionApp.test.ts
@@ -323,7 +323,51 @@ describe("Function App Resource", () => {
         expect(functionAppReserved.value).toBeUndefined();
       }
     });
+
+    describe("use32BitWorkerProcess", () => {
+      it("gets correct parameters - default", () => {
+        const config = getConfig(FunctionAppOS.WINDOWS, Runtime.NODE10);
+    
+        const resource = new FunctionAppResource();
+        
+        const params = resource.getParameters(config);
+        const {
+          functionUse32BitWorkerProcess,
+        } = params;
+    
+        expect(functionUse32BitWorkerProcess.value).toEqual(true);
+      });
+
+      it("gets correct parameters - true", () => {
+        const config = getConfig(FunctionAppOS.WINDOWS, Runtime.NODE12);
+        config.provider.use32BitWorkerProcess = true;
+    
+        const resource = new FunctionAppResource();
+        
+        const params = resource.getParameters(config);
+        const {
+          functionUse32BitWorkerProcess,
+        } = params;
+    
+        expect(functionUse32BitWorkerProcess.value).toEqual(true);
+      });
+
+      it("gets correct parameters - false", () => {
+        const config = getConfig(FunctionAppOS.WINDOWS, Runtime.NODE12);
+        config.provider.use32BitWorkerProcess = false;
+    
+        const resource = new FunctionAppResource();
+        
+        const params = resource.getParameters(config);
+        const {
+          functionUse32BitWorkerProcess,
+        } = params;
+    
+        expect(functionUse32BitWorkerProcess.value).toEqual(false);
+      });
+    });
   });
+
 
   function getConfig(os: FunctionAppOS, runtime: Runtime): ServerlessAzureConfig {
     return {

--- a/src/armTemplates/resources/functionApp.ts
+++ b/src/armTemplates/resources/functionApp.ts
@@ -97,6 +97,7 @@ export class FunctionAppResource implements ArmResourceTemplateGenerator {
             "siteConfig": {
               appSettings: this.getFunctionAppSettings(config), 
               "linuxFxVersion": "[parameters('linuxFxVersion')]",
+              "use32BitWorkerProcess": "[parameters('functionUse32BitWorkerProcess')]",
             },
             "reserved": "[parameters('functionAppReserved')]",
             name: "[parameters('functionAppName')]",
@@ -112,7 +113,7 @@ export class FunctionAppResource implements ArmResourceTemplateGenerator {
     const resourceConfig: FunctionAppConfig = {
       ...config.provider.functionApp,
     };
-    const { runtime, os } = config.provider;
+    const { runtime, os, use32BitWorkerProcess } = config.provider;
     const isLinuxRuntime = os === FunctionAppOS.LINUX;
 
     const params: FunctionAppParams = {
@@ -125,6 +126,9 @@ export class FunctionAppResource implements ArmResourceTemplateGenerator {
           `~${getRuntimeVersion(runtime)}`
           :
           undefined,
+      },
+      functionUse32BitWorkerProcess: {
+        value: (use32BitWorkerProcess === false) ? false : true,
       },
       functionAppRunFromPackage: {
         value: (isLinuxRuntime) ? "0" : "1",

--- a/src/models/serverless.ts
+++ b/src/models/serverless.ts
@@ -63,6 +63,7 @@ export interface ServerlessAzureProvider {
   /** Runtime setting within `serverless.yml` */
   runtime: Runtime;
   os?: FunctionAppOS;
+  use32BitWorkerProcess?: boolean;
 }
 
 /**


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless-azure-functions/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement: add provider parameter use32BitWorkerProcess

This feature adds the use32BitWorkerProcess parameter which is utilized in the arm template to determine if you will be using a 32-bit function or a 64-bit function.  No parameter previously existed to change the defaults which ultimately caused issues when implementing certain functionalities which required 64-bit functionality.

## How did you implement it:

Implementation was done by modifying the serverless model to allow the configuration in the model as optional, likewise modifying the functionApp armTemplate to provide the ability to set the proper fields when pushing the template up.  Unit tests have accompanied this change.

<!--
If this is a nontrivial change please briefly describe your implementation so it's easy for us to understand and review your code.
-->

## How can we verify it:

This can be verified by changing `serverless.yml` to:
```
provider:
  use32BitWorkerProcess: false
```

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

_**Note: Run `npm run test:ci` to run all validation checks on proposed changes**_

- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [?] Write documentation, docs aren't in the repo?
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES  
**_Is it a breaking change?:_** NO
