### PR TITLE
add nodejs16 as runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -310,10 +310,6 @@ Run unit tests using `npm test` or `npm run test:coverage` to get coverage resul
 
 We run our integration tests twice per day from our GitHub workflow. These tests install the beta version of the plugin, deploy a function app (with APIM), re-deploy (to make sure ARM template deployment is skipped), invoke the function directly, invoke the APIM endpoint and then remove the resource group, making assertions on the output at each step. While the number of configurations one could use in the Serverless Framework is virtually infinite, we tried to capture the main runtimes and platforms that are supported by the tool:
 
-- Node 10 on Linux using remote build
-- Node 10 on Linux using external package
-- Node 10 on Windows
-- Node 10 on Windows using webpack
 - Node 12 on Linux using remote build
 - Node 12 on Linux using external package
 - Node 12 on Linux using remote build and premium functions

--- a/README.md
+++ b/README.md
@@ -323,6 +323,9 @@ We run our integration tests twice per day from our GitHub workflow. These tests
 - Node 14 on Windows
 - Node 14 on Windows using premium functions
 - Node 14 on Windows using webpack
+- Node 16 on Windows
+- Node 16 on Windows using premium functions
+- Node 16 on Windows using webpack
 - Python 3.6 (Linux only)
 - Python 3.6 (Linux only) using premium functions
 - Python 3.7 (Linux only)

--- a/src/config/runtime.test.ts
+++ b/src/config/runtime.test.ts
@@ -2,46 +2,46 @@ import { Runtime, isNodeRuntime, isPythonRuntime, getRuntimeVersion, getRuntimeL
 
 
 describe("Runtime", () => {
-  it("identifies node runtimes correctly", () => {
-    expect(isNodeRuntime(Runtime.NODE10)).toBe(true);
+  it("identifies node runtimes correctly", () => {    
     expect(isNodeRuntime(Runtime.NODE12)).toBe(true);
     expect(isNodeRuntime(Runtime.NODE14)).toBe(true);
+    expect(isNodeRuntime(Runtime.NODE16)).toBe(true);
     expect(isNodeRuntime(Runtime.PYTHON36)).toBe(false);
     expect(isNodeRuntime(Runtime.PYTHON37)).toBe(false);
     expect(isNodeRuntime(Runtime.PYTHON38)).toBe(false);
   });
 
-  it("identifies python runtimes correctly", () => {
-    expect(isPythonRuntime(Runtime.NODE10)).toBe(false);
+  it("identifies python runtimes correctly", () => {    
     expect(isPythonRuntime(Runtime.NODE12)).toBe(false);
     expect(isPythonRuntime(Runtime.NODE14)).toBe(false);
+    expect(isPythonRuntime(Runtime.NODE16)).toBe(false);
     expect(isPythonRuntime(Runtime.PYTHON36)).toBe(true);
     expect(isPythonRuntime(Runtime.PYTHON37)).toBe(true);
     expect(isPythonRuntime(Runtime.PYTHON38)).toBe(true);
   });
 
-  it("gets runtime version", () => {
-    expect(getRuntimeVersion(Runtime.NODE10)).toBe("10");
+  it("gets runtime version", () => {    
     expect(getRuntimeVersion(Runtime.NODE12)).toBe("12");
     expect(getRuntimeVersion(Runtime.NODE14)).toBe("14");
+    expect(getRuntimeVersion(Runtime.NODE16)).toBe("16");
     expect(getRuntimeVersion(Runtime.PYTHON36)).toBe("3.6");
     expect(getRuntimeVersion(Runtime.PYTHON37)).toBe("3.7");
     expect(getRuntimeVersion(Runtime.PYTHON38)).toBe("3.8");
   });
 
-  it("gets runtime language", () => {
-    expect(getRuntimeLanguage(Runtime.NODE10)).toBe("nodejs");
+  it("gets runtime language", () => {    
     expect(getRuntimeLanguage(Runtime.NODE12)).toBe("nodejs");
     expect(getRuntimeLanguage(Runtime.NODE14)).toBe("nodejs");
+    expect(getRuntimeLanguage(Runtime.NODE16)).toBe("nodejs");
     expect(getRuntimeLanguage(Runtime.PYTHON36)).toBe("python");
     expect(getRuntimeLanguage(Runtime.PYTHON37)).toBe("python");
     expect(getRuntimeLanguage(Runtime.PYTHON38)).toBe("python");
   });
 
-  it("gets function worker runtime", () => {
-    expect(getFunctionWorkerRuntime(Runtime.NODE10)).toBe("node");
+  it("gets function worker runtime", () => {    
     expect(getFunctionWorkerRuntime(Runtime.NODE12)).toBe("node");
     expect(getFunctionWorkerRuntime(Runtime.NODE14)).toBe("node");
+    expect(getFunctionWorkerRuntime(Runtime.NODE16)).toBe("node");
     expect(getFunctionWorkerRuntime(Runtime.PYTHON36)).toBe("python");
     expect(getFunctionWorkerRuntime(Runtime.PYTHON37)).toBe("python");
     expect(getFunctionWorkerRuntime(Runtime.PYTHON38)).toBe("python");

--- a/src/config/runtime.ts
+++ b/src/config/runtime.ts
@@ -1,8 +1,8 @@
 
-export enum Runtime {
-  NODE10 = "nodejs10",
+export enum Runtime {  
   NODE12 = "nodejs12",
   NODE14 = "nodejs14",
+  NODE16 = "nodejs16",
   PYTHON36 = "python3.6",
   PYTHON37 = "python3.7",
   PYTHON38 = "python3.8",
@@ -10,10 +10,10 @@ export enum Runtime {
   DOTNET31 = "dotnet3.1",
 }
 
-export const supportedRuntimes = [
-  Runtime.NODE10,
+export const supportedRuntimes = [  
   Runtime.NODE12,
   Runtime.NODE14,
+  Runtime.NODE16,
   Runtime.PYTHON36,
   Runtime.PYTHON37,
   Runtime.PYTHON38,
@@ -88,10 +88,10 @@ export enum FunctionAppOS {
   LINUX = "linux"
 }
 
-export const dockerImages = {
-  nodejs10: "NODE|10",
+export const dockerImages = {  
   nodejs12: "NODE|12",
   nodejs14: "NODE|14",
+  nodejs14: "NODE|16",
   "python3.6": "PYTHON|3.6",
   "python3.7": "PYTHON|3.7",
   "python3.8": "PYTHON|3.8",

--- a/src/services/configService.test.ts
+++ b/src/services/configService.test.ts
@@ -225,7 +225,7 @@ describe("Config Service", () => {
         sls.service.provider.runtime = "python2.7" as any;
         expect(() => new ConfigService(sls, {} as any))
           .toThrowError("Runtime python2.7 is not supported. " +
-            "Runtimes supported: nodejs10,nodejs12,nodejs14,python3.6,python3.7,python3.8");
+            "Runtimes supported: nodejs12,nodejs14,nodejs16,python3.6,python3.7,python3.8");
       });
 
       it("throws error when incomplete nodejs version in defined", () => {
@@ -233,7 +233,7 @@ describe("Config Service", () => {
         sls.service.provider.runtime = "nodejs" as any;
         expect(() => new ConfigService(sls, {} as any))
           .toThrowError("Runtime nodejs is not supported. " +
-            "Runtimes supported: nodejs10,nodejs12,nodejs14,python3.6,python3.7,python3.8");
+            "Runtimes supported: nodejs12,nodejs14,nodejs16,python3.6,python3.7,python3.8");
       });
 
       it("throws error when unsupported nodejs version in defined", () => {
@@ -241,12 +241,12 @@ describe("Config Service", () => {
         sls.service.provider.runtime = "nodejs5.x" as any;
         expect(() => new ConfigService(sls, {} as any))
           .toThrowError("Runtime nodejs5.x is not supported. " +
-            "Runtimes supported: nodejs10,nodejs12,nodejs14,python3.6,python3.7,python3.8");
+            "Runtimes supported: nodejs12,nodejs14,nodejs16,python3.6,python3.7,python3.8");
       });
 
       it("Does not throw an error when valid nodejs version is defined", () => {
         const sls = MockFactory.createTestServerless();
-        sls.service.provider.runtime = Runtime.NODE10
+        sls.service.provider.runtime = Runtime.NODE12
         let configService: ConfigService;
         expect(() => configService = new ConfigService(sls, {} as any)).not.toThrow();
         expect(configService.isLinuxTarget()).toBe(false);
@@ -258,7 +258,7 @@ describe("Config Service", () => {
         sls.service.provider.runtime = undefined;
         expect(() => new ConfigService(sls, {} as any))
           .toThrowError("Runtime undefined. " +
-            "Runtimes supported: nodejs10,nodejs12,nodejs14,python3.6,python3.7,python3.8");
+            "Runtimes supported: nodejs12,nodejs14,nodejs16,python3.6,python3.7,python3.8");
       });
 
       it("does not throw an error with python3.6", () => {


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless-azure-functions/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:
Added support  for node16 and removed node10,, similar to this change https://github.com/serverless/serverless-azure-functions/pull/537/commits 
Closes #XXXXX

<!--
Briefly describe the feature if no issue exists for this PR
-->
I saw this issue when I tried deplpying with nodejs16 runtime.
```
Error:
Error: Runtime nodejs16 is not supported. Runtimes supported: nodejs10,nodejs12,nodejs14,python3.6,python3.7,python3.8,dotnet2.2,dotnet3.1
    at ConfigService.initializeConfig (/home/g115386/notifications/node_modules/serverless-azure-functions/lib/services/configService.js:195:19)
    at new ConfigService (/home/g115386/notifications/node_modules/serverless-azure-functions/lib/services/configService.js:26:28)
    at new AzurePackagePlugin (/home/g115386/notifications/node_modules/serverless-azure-functions/lib/plugins/package/azurePackagePlugin.js:67:29)
```

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so it's easy for us to understand and review your code.
-->
Changed src/config/runtime, src/config/runtime.test.ts, src/services/configService.test.ts and readme

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

I made these changes locally and I tried with nodejs16 as runtime serverless.yml, and it didn't  throw warning 

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place
* Other - Anything else that comes to mind to help us evaluate
-->

## Todos:

_**Note: Run `npm run test:ci` to run all validation checks on proposed changes**_

- [ ] Ensure there are no lint errors.  
       **Validate via `npm run lint`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [ ] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [ ] Write documentation
- [ ] Provide verification config / commands / resources
- [ ] Enable "Allow edits from maintainers" for this PR
- [ ] Update the messages below

**_Is this ready for review?:_** NO  
**_Is it a breaking change?:_** NO
