### PR TITLE
fix: Add support for .net 6 runtime (closes #614)

### DIFF
--- a/src/config/runtime.test.ts
+++ b/src/config/runtime.test.ts
@@ -47,5 +47,6 @@ describe("Runtime", () => {
     expect(getFunctionWorkerRuntime(Runtime.PYTHON38)).toBe("python");
     expect(getFunctionWorkerRuntime(Runtime.DOTNET31)).toBe("dotnet");
     expect(getFunctionWorkerRuntime(Runtime.DOTNET22)).toBe("dotnet");
+    expect(getFunctionWorkerRuntime(Runtime.DOTNET60)).toBe("dotnet");
   });
 });

--- a/src/config/runtime.ts
+++ b/src/config/runtime.ts
@@ -8,6 +8,7 @@ export enum Runtime {
   PYTHON38 = "python3.8",
   DOTNET22 = "dotnet2.2",
   DOTNET31 = "dotnet3.1",
+  DOTNET60 = "dotnet6.0",
 }
 
 export const supportedRuntimes = [
@@ -18,7 +19,8 @@ export const supportedRuntimes = [
   Runtime.PYTHON37,
   Runtime.PYTHON38,
   Runtime.DOTNET22,
-  Runtime.DOTNET31
+  Runtime.DOTNET31,
+  Runtime.DOTNET60
 ]
 
 export const supportedRuntimeSet = new Set(supportedRuntimes);
@@ -42,7 +44,8 @@ export enum BuildMode {
 
 export const compiledRuntimes = new Set([
   Runtime.DOTNET22,
-  Runtime.DOTNET31
+  Runtime.DOTNET31,
+  Runtime.DOTNET60,
 ]);
 
 export function isCompiledRuntime(runtime: Runtime): boolean {
@@ -96,4 +99,5 @@ export const dockerImages = {
   "python3.7": "PYTHON|3.7",
   "python3.8": "PYTHON|3.8",
   "dotnet3.1": "DOTNET|3.1",
+  "dotnet6.0": "DOTNET|6.0",
 }

--- a/src/services/configService.ts
+++ b/src/services/configService.ts
@@ -350,5 +350,31 @@ export class ConfigService {
         constants.tmpBuildDir
       ],
     });
+    
+    this.cliCommandFactory.registerCommand(`${Runtime.DOTNET60}-${BuildMode.RELEASE}`, {
+      command: "dotnet",
+      args: [
+        "build",
+        "--configuration",
+        "release",
+        "--framework",
+        "net6.0",
+        "--output",
+        constants.tmpBuildDir
+      ],
+    });
+    
+    this.cliCommandFactory.registerCommand(`${Runtime.DOTNET60}-${BuildMode.DEBUG}`, {
+      command: "dotnet",
+      args: [
+        "build",
+        "--configuration",
+        "debug",
+        "--framework",
+        "net6.0",
+        "--output",
+        constants.tmpBuildDir
+      ],
+    });
   }
 }


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless-azure-functions/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:
Added .net6 runtime version to configs. Without it we were not able to use this runtime in `serverless.yml`.
Closes #614

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:
I've added DOTNET60 to enum Runtime, other necessary structures and register commands so that it can be build.
<!--
If this is a nontrivial change please briefly describe your implementation so it's easy for us to understand and review your code.
-->

## How can we verify it:

Use `runtime: dotnet6.0` in `serverless.yml` file.
Use project targeting net6.0, also azure functions v4 can be used:

Examples:
* serverless.yml - provider part
```
...
provider:
  name: azure
  region: West Europe
  functionApp:
    extensionVersion: '~4'
  runtime: dotnet6.0
 ...
```
* .csproj - target version for net6.0
```
<Project Sdk="Microsoft.NET.Sdk">
  <PropertyGroup>
    <TargetFramework>net6.0</TargetFramework>
    <AzureFunctionsVersion>v4</AzureFunctionsVersion>
...
```
## Todos:

_**Note: Run `npm run test:ci` to run all validation checks on proposed changes**_

- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [ ] Write documentation
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES 
**_Is it a breaking change?:_** NO
