### PR TITLE
fix: Updated publishing script and only run tag on the main repo, not forks

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -194,6 +194,7 @@ jobs:
   tag-if-new-version:
     runs-on: ubuntu-latest
     needs: [node-integration-tests, python-integration-tests]
+    if: github.repository_owner == 'serverless'
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,7 +45,7 @@ jobs:
           npm ci
 
       - name: Build local package
-        run: npm pack
+        run: npm run build
 
       - name: Publish new version
         # Note: Setting NODE_AUTH_TOKEN as job|workspace wide env var won't work

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,6 +44,9 @@ jobs:
         run: |
           npm ci
 
+      - name: Build local package
+        run: npm pack
+
       - name: Publish new version
         # Note: Setting NODE_AUTH_TOKEN as job|workspace wide env var won't work
         #       as it appears actions/setup-node sets own value

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,6 +54,6 @@ jobs:
       - name: Create and publish a release
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${GITHUB_REF##*/}
+          tag_name: ${{ github.ref_name }}
           prerelease: false
           generate_release_notes: true


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless-azure-functions/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

When I merged the master branch this started failing in my repo, so adding this to only run the tag on the main repo, not on forks

## Todos:

_**Note: Run `npm run test:ci` to run all validation checks on proposed changes**_

- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [x] Write documentation
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES  
**_Is it a breaking change?:_** NO
