### PR TITLE
fix: remove unused `semver` dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,6 @@
         "querystring": "^0.2.0",
         "request": "^2.81.0",
         "rimraf": "^2.7.1",
-        "semver": "^6.3.0",
         "xml2js": "^0.4.22",
         "zip-folder": "^1.0.0"
       },
@@ -12451,6 +12450,7 @@
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
       "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true,
       "bin": {
         "semver": "bin/semver.js"
       }
@@ -25927,7 +25927,8 @@
     "semver": {
       "version": "6.3.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+      "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+      "dev": true
     },
     "semver-diff": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "querystring": "^0.2.0",
     "request": "^2.81.0",
     "rimraf": "^2.7.1",
-    "semver": "^6.3.0",
     "xml2js": "^0.4.22",
     "zip-folder": "^1.0.0"
   },


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless-azure-functions/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

The `semver` package is no longer being used, so it doesn't need to be listed as a dependency.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so it's easy for us to understand and review your code.
-->

I removed it from `dependencies` in `package.json`

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place
* Other - Anything else that comes to mind to help us evaluate
-->

```
❯ rg --files-with-matches 'semver'
integrationTests/configurations/node16-linux-webpack/package-lock.json
integrationTests/configurations/node12-linux/package-lock.json
integrationTests/configurations/node18-linux-webpack/package-lock.json
integrationTests/configurations/node14-windows/package-lock.json
integrationTests/configurations/node16-linux/package-lock.json
integrationTests/configurations/node12-linux-webpack/package-lock.json
integrationTests/configurations/node16-windows-webpack/package-lock.json
integrationTests/configurations/node14-windows-webpack/package-lock.json
integrationTests/configurations/node18-windows-webpack/package-lock.json
integrationTests/configurations/node16-windows/package-lock.json
integrationTests/configurations/node18-windows/package-lock.json
integrationTests/configurations/node12-windows-webpack/package-lock.json
integrationTests/configurations/node12-windows/package-lock.json
integrationTests/configurations/node14-linux-webpack/package-lock.json
integrationTests/configurations/node14-linux/package-lock.json
integrationTests/configurations/node18-linux/package-lock.json
examples/typescript-webpack/package-lock.json
package-lock.json
```

If `semver` was being used by this package, then there should have been a match in either a TypeScript or JavaScript file, which there was not.

The tests also will fail if `semver` is actually needed.

## Todos:

_**Note: Run `npm run test:ci` to run all validation checks on proposed changes**_

- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [x] Write documentation
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
