### PR TITLE
refactor: remove `lodash`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,6 @@
         "deep-equal": "^1.0.1",
         "js-yaml": "^3.13.1",
         "jsonpath": "^1.0.1",
-        "lodash": "^4.16.6",
         "md5": "^2.2.1",
         "open": "^6.3.0",
         "querystring": "^0.2.0",
@@ -9928,7 +9927,8 @@
     "node_modules/lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "devOptional": true
     },
     "node_modules/lodash._reinterpolate": {
       "version": "3.0.0",
@@ -23850,7 +23850,8 @@
     "lodash": {
       "version": "4.17.11",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "devOptional": true
     },
     "lodash._reinterpolate": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "deep-equal": "^1.0.1",
     "js-yaml": "^3.13.1",
     "jsonpath": "^1.0.1",
-    "lodash": "^4.16.6",
     "md5": "^2.2.1",
     "open": "^6.3.0",
     "querystring": "^0.2.0",

--- a/src/services/apimService.test.ts
+++ b/src/services/apimService.test.ts
@@ -1,7 +1,6 @@
 import { Api, ApiManagementService, ApiOperation, ApiOperationPolicy, ApiPolicy, Backend, Property } from "@azure/arm-apimanagement";
 import { ApiContract, ApiCreateOrUpdateResponse, ApiGetResponse, ApiManagementServiceGetResponse, ApiManagementServiceResource, ApiOperationCreateOrUpdateResponse, ApiPolicyCreateOrUpdateResponse, ApiPolicyGetResponse, BackendContract, BackendCreateOrUpdateResponse, OperationContract, PolicyContract, PropertyContract, PropertyCreateOrUpdateResponse } from "@azure/arm-apimanagement/esm/models";
 import axios from "axios";
-import _ from "lodash";
 import Serverless from "serverless";
 import { Runtime } from "../config/runtime";
 import { ApiCheckHeaderPolicy, ApiIpFilterPolicy, ApiManagementConfig } from "../models/apiManagement";
@@ -676,7 +675,7 @@ describe("APIM Service", () => {
     });
 
     it("ensures all serverless functions have been deployed into specified API", async () => {
-      const slsFunctions = _.values(serverless.service["functions"]);
+      const slsFunctions = Object.values(serverless.service["functions"]);
 
       let apimResource: ApiManagementServiceResource = {
         name: apimConfig.name,


### PR DESCRIPTION
<!--
1. Please check out and follow our Contributing Guidelines: https://github.com/serverless/serverless-azure-functions/blob/master/CONTRIBUTING.md
2. Do not remove any section of the template. If something is not applicable leave it empty but leave it in the PR
3. Please follow the template, otherwise we'll have to ask you to update it and it will take longer until your PR is merged
-->

## What did you implement:

Removed `lodash` as a required dependency for this plugin.

<!--
Briefly describe the feature if no issue exists for this PR
-->

## How did you implement it:

<!--
If this is a nontrivial change please briefly describe your implementation so it's easy for us to understand and review your code.
-->

I replaced the single usage of `lodash` with a native equivalent, and then I removed it from `dependencies` in `package.json`

## How can we verify it:

<!--
Add any applicable config, commands, screenshots or other resources
to make it easy for us to verify this works. The easier you make it for us
to review a PR, the faster we can review and merge it.

Examples:
* serverless.yml - Fully functioning to easily deploy changes
* Screenshots - Showing the difference between your output and the master
* Cloud Configuration - List cloud resources and show that the correct configuration is in place
* Other - Anything else that comes to mind to help us evaluate
-->

```
❯ rg --files-with-matches 'lodash'
integrationTests/configurations/node16-linux-webpack/package-lock.json
integrationTests/configurations/node12-linux/package-lock.json
integrationTests/configurations/node18-linux-webpack/package-lock.json
integrationTests/configurations/node14-windows/package-lock.json
integrationTests/configurations/node16-linux/package-lock.json
integrationTests/configurations/node12-linux-webpack/package-lock.json
integrationTests/configurations/node18-windows-webpack/package-lock.json
integrationTests/configurations/node16-windows-webpack/package-lock.json
integrationTests/configurations/node14-windows-webpack/package-lock.json
integrationTests/configurations/node16-windows/package-lock.json
integrationTests/configurations/node18-windows/package-lock.json
integrationTests/configurations/node12-windows-webpack/package-lock.json
integrationTests/configurations/node12-windows/package-lock.json
integrationTests/configurations/node14-linux-webpack/package-lock.json
integrationTests/configurations/node14-linux/package-lock.json
integrationTests/configurations/node18-linux/package-lock.json
examples/typescript-webpack/package-lock.json
package-lock.json
```

If `lodash` was being used by this package, then there should have been a match in either a TypeScript or JavaScript file, which there was not.

The tests also will fail if `lodash` is actually still needed.

## Todos:

_**Note: Run `npm run test:ci` to run all validation checks on proposed changes**_

- [x] Ensure there are no lint errors.  
       **Validate via `npm run lint`**  
       _Note: Some reported issues can be automatically fixed by running `npm run lint:fix`_
- [x] Write tests and confirm existing functionality is not broken.  
       **Validate via `npm test`**
- [x] Write documentation
- [x] Provide verification config / commands / resources
- [x] Enable "Allow edits from maintainers" for this PR
- [x] Update the messages below

**_Is this ready for review?:_** YES
**_Is it a breaking change?:_** NO
